### PR TITLE
clean up imports and add missing funcs

### DIFF
--- a/ipynb/add_conf_demo.ipynb
+++ b/ipynb/add_conf_demo.ipynb
@@ -2,21 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 63,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "The autoreload extension is already loaded. To reload it, use:\n",
-      "  %reload_ext autoreload\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "#from hydra_zen import add_conf, add_func_conf, ConfMode, _add_conf, cs, zen_dry_run, launch_and_instantiate\n",
-    "from hydra_zen.structured_configs._add_conf import ConfMode, add_conf, ZenExtras, cs\n",
+    "#from hydra_zen import add_batteries, add_func_conf, ConfMode, _add_batteries, cs, zen_dry_run, launch_and_instantiate\n",
+    "from hydra_zen.structured_configs._add_conf import ConfMode, add_batteries, add_batteries, BatteriesIncludedConf, cs\n",
     "from hydra_zen import launch, instantiate\n",
     "from typing import Any, List\n",
     "from omegaconf import MISSING\n",
@@ -28,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,10 +38,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# using `add_conf`"
+    "# using `add_batteries`"
    ]
   },
   {
@@ -62,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 98,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -71,13 +63,13 @@
        "MyClass(dog, 3)"
       ]
      },
-     "execution_count": 98,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "@add_conf(hydra_recursive=False)\n",
+    "@add_batteries\n",
     "class MyClass:\n",
     "    def __init__(\n",
     "        self,\n",
@@ -95,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 99,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -104,7 +96,7 @@
        "types.Builds_MyClass"
       ]
      },
-     "execution_count": 99,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -116,16 +108,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='dog', b=3, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='dog', b=3, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 85,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -138,16 +130,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 101,
+     "execution_count": 23,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -159,16 +151,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'_target_: hydra_zen.funcs.zen_processing\\n_zen_target: __main__.MyClass\\n_zen_exclude:\\n- name_\\n- group_\\n- package_\\n- provider_\\n- defaults\\n_recursive_: false\\na: dog\\nb: 3\\nname_: null\\ngroup_: null\\npackage_: _group_\\nprovider_: null\\ndefaults:\\n- _self_\\n'"
+       "MyClass(dog, 3)"
       ]
      },
-     "execution_count": 103,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -180,7 +172,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -189,7 +181,7 @@
        "MyClass(Bloom, 3)"
       ]
      },
-     "execution_count": 88,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -201,16 +193,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 89,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -229,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 90,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -238,7 +230,7 @@
        "MyClass(Lily, 3)"
       ]
      },
-     "execution_count": 90,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -271,7 +263,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -280,7 +272,7 @@
        "MyClass(Bloom, 47)"
       ]
      },
-     "execution_count": 92,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -294,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 95,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -303,7 +295,7 @@
        "MyClass(Bloom, 117)"
       ]
      },
-     "execution_count": 95,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -317,7 +309,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -326,7 +318,7 @@
        "MyClass(Lily, 117)"
       ]
      },
-     "execution_count": 96,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -337,42 +329,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 100,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "issubclass(MyClass.Conf,ZenExtras)"
+    "issubclass(MyClass.Conf, BatteriesIncludedConf)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 97,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "False"
+       "True"
       ]
      },
-     "execution_count": 97,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "isinstance(my_class.conf,ZenExtras)"
+    "isinstance(my_class.conf, BatteriesIncludedConf)"
    ]
   },
   {
@@ -384,17 +376,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [],
    "source": [
     "from sklearn.linear_model import LogisticRegression\n",
-    "WrappedLogisticRegression = add_conf(LogisticRegression)"
+    "WrappedLogisticRegression = add_batteries(LogisticRegression)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -424,19 +416,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "<style>#sk-container-id-1 {color: black;background-color: white;}#sk-container-id-1 pre{padding: 0;}#sk-container-id-1 div.sk-toggleable {background-color: white;}#sk-container-id-1 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-1 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-1 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-1 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-1 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-1 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-1 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-1 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-1 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-1 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-1 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-1 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-1 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-1 div.sk-item {position: relative;z-index: 1;}#sk-container-id-1 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-1 div.sk-item::before, #sk-container-id-1 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-1 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-1 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-1 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-1 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-1 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-1 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-1 div.sk-label-container {text-align: center;}#sk-container-id-1 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-1 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-1\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>LogisticRegression(penalty=&#x27;l1&#x27;)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-1\" type=\"checkbox\" checked><label for=\"sk-estimator-id-1\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">LogisticRegression</label><div class=\"sk-toggleable__content\"><pre>LogisticRegression(penalty=&#x27;l1&#x27;)</pre></div></div></div></div></div>"
-      ],
       "text/plain": [
        "LogisticRegression(penalty='l1')"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -448,24 +437,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/torch/nn/modules/lazy.py:178: UserWarning: Lazy modules are a new feature under heavy development so changes to the API or functionality can happen at any moment.\n",
-      "  warnings.warn('Lazy modules are a new feature under heavy development '\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "LazyLinear(in_features=0, out_features=2, bias=True)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -473,13 +454,13 @@
    "source": [
     "# another example\n",
     "from torch import nn\n",
-    "LazyLinear = add_conf(nn.LazyLinear)\n",
+    "LazyLinear = add_batteries(nn.LazyLinear)\n",
     "LazyLinear.Conf(out_features=2).instantiate()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
@@ -488,25 +469,25 @@
        "Builds_LogisticRegression(_target_='hydra_zen.funcs.zen_processing', _zen_target='sklearn.linear_model._logistic.LogisticRegression', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), penalty='l2', dual=False, tol=0.0001, C=1.0, fit_intercept=True, intercept_scaling=1, class_weight=None, random_state=None, solver='lbfgs', max_iter=100, multi_class='auto', verbose=0, warm_start=False, n_jobs=None, l1_ratio=None, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# can overwrite imports, this might be sus but could be useful for backwards compatibility\n",
-    "LogisticRegression = add_conf(LogisticRegression)\n",
+    "LogisticRegression = add_batteries(LogisticRegression)\n",
     "LogisticRegression.Conf()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
     "# idempotent\n",
-    "LogisticRegression = add_conf(add_conf(add_conf(add_conf(add_conf(LogisticRegression)))))"
+    "LogisticRegression = add_batteries(add_batteries(add_batteries(add_batteries(add_batteries(LogisticRegression)))))"
    ]
   },
   {
@@ -625,11 +606,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@add_conf\n",
+    "@add_batteries\n",
     "class TopLevelClass:\n",
     "    def __init__(\n",
     "        self,\n",
@@ -643,7 +624,7 @@
     "    def __repr__(self):\n",
     "        return f'TopLevelClass({self.a}, {self.lower_level_class})'\n",
     "        \n",
-    "@add_conf        \n",
+    "@add_batteries        \n",
     "class LowerLevelClass:\n",
     "    def __init__(\n",
     "        self,\n",
@@ -658,7 +639,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -667,7 +648,7 @@
        "LowerLevelClass(hello)"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -682,25 +663,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['_dummy_empty_config_.yaml',\n",
-       " 'hydra',\n",
-       " 'llc_group',\n",
-       " 'lower_level_class',\n",
-       " 'lower_level_class_1.yaml',\n",
-       " 'lower_level_class_2.yaml',\n",
-       " 'mlc_group',\n",
-       " 'top_level_class.yaml',\n",
-       " 'top_level_class_2.yaml',\n",
-       " 'zen_launch.yaml']"
+       "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b='hello', name_='lower_level_class_1', group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 69,
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lower_level_class.conf.store()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['_dummy_empty_config_.yaml', 'hydra']"
+      ]
+     },
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -712,7 +704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -721,7 +713,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b=99, name_='lower_level_class_2', group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 70,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -736,25 +728,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 71,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['_dummy_empty_config_.yaml',\n",
-       " 'hydra',\n",
-       " 'llc_group',\n",
-       " 'lower_level_class',\n",
-       " 'lower_level_class_1.yaml',\n",
-       " 'lower_level_class_2.yaml',\n",
-       " 'mlc_group',\n",
-       " 'top_level_class.yaml',\n",
-       " 'top_level_class_2.yaml',\n",
-       " 'zen_launch.yaml']"
+       "['_dummy_empty_config_.yaml', 'hydra']"
       ]
      },
-     "execution_count": 71,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -765,7 +748,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -774,7 +757,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b=99, name_='lower_level_class_4', group_='lower_level_class', package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 72,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -795,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -804,7 +787,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b='hello', name_='lower_level_class_3', group_='lower_level_class', package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -818,7 +801,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -831,18 +814,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "TopLevelClass(0, LowerLevelClass(hello))"
-      ]
-     },
-     "execution_count": 77,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/naka/code/hydra-zen/src/hydra_zen/_launch.py:236: UserWarning: \n",
+      "The version_base parameter is not specified.\n",
+      "Please specify a compatability version level, or None.\n",
+      "Will assume defaults for version 1.1\n",
+      "  with initialize(\n"
+     ]
+    },
+    {
+     "ename": "MissingConfigException",
+     "evalue": "In 'zen_launch': Could not find 'lower_level_class/lower_level_class_3'\n\nConfig search path:\n\tprovider=hydra, path=pkg://hydra.conf\n\tprovider=schema, path=structured://",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mMissingConfigException\u001b[0m                    Traceback (most recent call last)",
+      "\u001b[1;32m/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb Cell 41\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X54sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m out \u001b[39m=\u001b[39m launch(top_level_class_config, launch_and_instantiate)\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X54sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
+      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/_launch.py:251\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    250\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> 251\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    252\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    253\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    254\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    255\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    256\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    257\u001b[0m )\n\u001b[1;32m    259\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    260\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    261\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    262\u001b[0m )\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    576\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    577\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    578\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    583\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    584\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    585\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    586\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    587\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    591\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    592\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 594\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    595\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    596\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    597\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    598\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    599\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    600\u001b[0m     )\n\u001b[1;32m    601\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    602\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:142\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    133\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    134\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    135\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    139\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    140\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    141\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 142\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    143\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    144\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    145\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    146\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    147\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    148\u001b[0m         )\n\u001b[1;32m    149\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    150\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:253\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39mif\u001b[39;00m validate_sweep_overrides:\n\u001b[1;32m    249\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mvalidate_sweep_overrides_legal(\n\u001b[1;32m    250\u001b[0m         overrides\u001b[39m=\u001b[39mparsed_overrides, run_mode\u001b[39m=\u001b[39mrun_mode, from_shell\u001b[39m=\u001b[39mfrom_shell\n\u001b[1;32m    251\u001b[0m     )\n\u001b[0;32m--> 253\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    254\u001b[0m     repo\u001b[39m=\u001b[39;49mcaching_repo,\n\u001b[1;32m    255\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    256\u001b[0m     overrides_list\u001b[39m=\u001b[39;49mparsed_overrides,\n\u001b[1;32m    257\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    258\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mrun_mode \u001b[39m==\u001b[39;49m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    259\u001b[0m )\n\u001b[1;32m    261\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[1;32m    263\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_compose_config_from_defaults_list(\n\u001b[1;32m    264\u001b[0m     defaults\u001b[39m=\u001b[39mdefaults_list\u001b[39m.\u001b[39mdefaults, repo\u001b[39m=\u001b[39mcaching_repo\n\u001b[1;32m    265\u001b[0m )\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:746\u001b[0m, in \u001b[0;36mcreate_defaults_list\u001b[0;34m(repo, config_name, overrides_list, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    737\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    738\u001b[0m \u001b[39m:param repo:\u001b[39;00m\n\u001b[1;32m    739\u001b[0m \u001b[39m:param config_name:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    743\u001b[0m \u001b[39m:return:\u001b[39;00m\n\u001b[1;32m    744\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    745\u001b[0m overrides \u001b[39m=\u001b[39m Overrides(repo\u001b[39m=\u001b[39mrepo, overrides_list\u001b[39m=\u001b[39moverrides_list)\n\u001b[0;32m--> 746\u001b[0m defaults, tree \u001b[39m=\u001b[39m _create_defaults_list(\n\u001b[1;32m    747\u001b[0m     repo,\n\u001b[1;32m    748\u001b[0m     config_name,\n\u001b[1;32m    749\u001b[0m     overrides,\n\u001b[1;32m    750\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49mprepend_hydra,\n\u001b[1;32m    751\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    752\u001b[0m )\n\u001b[1;32m    753\u001b[0m overrides\u001b[39m.\u001b[39mensure_overrides_used()\n\u001b[1;32m    754\u001b[0m overrides\u001b[39m.\u001b[39mensure_deletions_used()\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:716\u001b[0m, in \u001b[0;36m_create_defaults_list\u001b[0;34m(repo, config_name, overrides, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    706\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_create_defaults_list\u001b[39m(\n\u001b[1;32m    707\u001b[0m     repo: IConfigRepository,\n\u001b[1;32m    708\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    711\u001b[0m     skip_missing: \u001b[39mbool\u001b[39m,\n\u001b[1;32m    712\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m Tuple[List[ResultDefault], DefaultsTreeNode]:\n\u001b[1;32m    714\u001b[0m     root \u001b[39m=\u001b[39m _create_root(config_name\u001b[39m=\u001b[39mconfig_name, with_hydra\u001b[39m=\u001b[39mprepend_hydra)\n\u001b[0;32m--> 716\u001b[0m     defaults_tree \u001b[39m=\u001b[39m _create_defaults_tree(\n\u001b[1;32m    717\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    718\u001b[0m         root\u001b[39m=\u001b[39;49mroot,\n\u001b[1;32m    719\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    720\u001b[0m         is_root_config\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    721\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    722\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    723\u001b[0m     )\n\u001b[1;32m    725\u001b[0m     output \u001b[39m=\u001b[39m _tree_to_list(tree\u001b[39m=\u001b[39mdefaults_tree)\n\u001b[1;32m    726\u001b[0m     ensure_no_duplicates_in_list(output)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:356\u001b[0m, in \u001b[0;36m_create_defaults_tree\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    348\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_create_defaults_tree\u001b[39m(\n\u001b[1;32m    349\u001b[0m     repo: IConfigRepository,\n\u001b[1;32m    350\u001b[0m     root: DefaultsTreeNode,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    354\u001b[0m     overrides: Overrides,\n\u001b[1;32m    355\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DefaultsTreeNode:\n\u001b[0;32m--> 356\u001b[0m     ret \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    357\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    358\u001b[0m         root\u001b[39m=\u001b[39;49mroot,\n\u001b[1;32m    359\u001b[0m         is_root_config\u001b[39m=\u001b[39;49mis_root_config,\n\u001b[1;32m    360\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    361\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49minterpolated_subtree,\n\u001b[1;32m    362\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    363\u001b[0m     )\n\u001b[1;32m    365\u001b[0m     \u001b[39mreturn\u001b[39;00m ret\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:457\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    455\u001b[0m \u001b[39mif\u001b[39;00m parent\u001b[39m.\u001b[39mis_virtual():\n\u001b[1;32m    456\u001b[0m     \u001b[39mif\u001b[39;00m is_root_config:\n\u001b[0;32m--> 457\u001b[0m         \u001b[39mreturn\u001b[39;00m _expand_virtual_root(repo, root, overrides, skip_missing)\n\u001b[1;32m    458\u001b[0m     \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    459\u001b[0m         \u001b[39mreturn\u001b[39;00m root\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:280\u001b[0m, in \u001b[0;36m_expand_virtual_root\u001b[0;34m(repo, root, overrides, skip_missing)\u001b[0m\n\u001b[1;32m    277\u001b[0m new_root \u001b[39m=\u001b[39m DefaultsTreeNode(node\u001b[39m=\u001b[39md, parent\u001b[39m=\u001b[39mroot)\n\u001b[1;32m    278\u001b[0m d\u001b[39m.\u001b[39mupdate_parent(\u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m--> 280\u001b[0m subtree \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    281\u001b[0m     repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    282\u001b[0m     root\u001b[39m=\u001b[39;49mnew_root,\n\u001b[1;32m    283\u001b[0m     is_root_config\u001b[39m=\u001b[39;49md\u001b[39m.\u001b[39;49mprimary,\n\u001b[1;32m    284\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    285\u001b[0m     interpolated_subtree\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    286\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    287\u001b[0m )\n\u001b[1;32m    288\u001b[0m \u001b[39mif\u001b[39;00m subtree\u001b[39m.\u001b[39mchildren \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    289\u001b[0m     children\u001b[39m.\u001b[39mappend(d)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:573\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    570\u001b[0m                 \u001b[39mcontinue\u001b[39;00m\n\u001b[1;32m    572\u001b[0m             new_root \u001b[39m=\u001b[39m DefaultsTreeNode(node\u001b[39m=\u001b[39md, parent\u001b[39m=\u001b[39mroot)\n\u001b[0;32m--> 573\u001b[0m             add_child(children, new_root)\n\u001b[1;32m    575\u001b[0m \u001b[39m# processed deferred interpolations\u001b[39;00m\n\u001b[1;32m    576\u001b[0m known_choices \u001b[39m=\u001b[39m _create_interpolation_map(overrides, defaults_list, self_added)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:520\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl.<locals>.add_child\u001b[0;34m(child_list, new_root_)\u001b[0m\n\u001b[1;32m    516\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39madd_child\u001b[39m(\n\u001b[1;32m    517\u001b[0m     child_list: List[Union[InputDefault, DefaultsTreeNode]],\n\u001b[1;32m    518\u001b[0m     new_root_: DefaultsTreeNode,\n\u001b[1;32m    519\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 520\u001b[0m     subtree_ \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    521\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    522\u001b[0m         root\u001b[39m=\u001b[39;49mnew_root_,\n\u001b[1;32m    523\u001b[0m         is_root_config\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    524\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49minterpolated_subtree,\n\u001b[1;32m    525\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    526\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    527\u001b[0m     )\n\u001b[1;32m    528\u001b[0m     \u001b[39mif\u001b[39;00m subtree_\u001b[39m.\u001b[39mchildren \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    529\u001b[0m         child_list\u001b[39m.\u001b[39mappend(new_root_\u001b[39m.\u001b[39mnode)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:488\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    486\u001b[0m         parent\u001b[39m.\u001b[39mdeleted \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n\u001b[1;32m    487\u001b[0m         \u001b[39mreturn\u001b[39;00m root\n\u001b[0;32m--> 488\u001b[0m     config_not_found_error(repo\u001b[39m=\u001b[39;49mrepo, tree\u001b[39m=\u001b[39;49mroot)\n\u001b[1;32m    490\u001b[0m \u001b[39massert\u001b[39;00m loaded \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    491\u001b[0m defaults_list \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(loaded\u001b[39m.\u001b[39mdefaults_list)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:800\u001b[0m, in \u001b[0;36mconfig_not_found_error\u001b[0;34m(repo, tree)\u001b[0m\n\u001b[1;32m    797\u001b[0m lines \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39mjoin(descs)\n\u001b[1;32m    798\u001b[0m msg \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39mConfig search path:\u001b[39m\u001b[39m\"\u001b[39m \u001b[39m+\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00mlines\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 800\u001b[0m \u001b[39mraise\u001b[39;00m MissingConfigException(\n\u001b[1;32m    801\u001b[0m     missing_cfg_file\u001b[39m=\u001b[39melement\u001b[39m.\u001b[39mget_config_path(),\n\u001b[1;32m    802\u001b[0m     message\u001b[39m=\u001b[39mmsg,\n\u001b[1;32m    803\u001b[0m     options\u001b[39m=\u001b[39moptions,\n\u001b[1;32m    804\u001b[0m )\n",
+      "\u001b[0;31mMissingConfigException\u001b[0m: In 'zen_launch': Could not find 'lower_level_class/lower_level_class_3'\n\nConfig search path:\n\tprovider=hydra, path=pkg://hydra.conf\n\tprovider=schema, path=structured://"
+     ]
     }
    ],
    "source": [
@@ -852,18 +860,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 78,
+   "execution_count": 53,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "TopLevelClass(0, LowerLevelClass(99))"
-      ]
-     },
-     "execution_count": 78,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/naka/code/hydra-zen/src/hydra_zen/_launch.py:236: UserWarning: \n",
+      "The version_base parameter is not specified.\n",
+      "Please specify a compatability version level, or None.\n",
+      "Will assume defaults for version 1.1\n",
+      "  with initialize(\n"
+     ]
+    },
+    {
+     "ename": "MissingConfigException",
+     "evalue": "In 'zen_launch': Could not find 'lower_level_class/lower_level_class_3'\n\nConfig search path:\n\tprovider=hydra, path=pkg://hydra.conf\n\tprovider=schema, path=structured://",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mMissingConfigException\u001b[0m                    Traceback (most recent call last)",
+      "\u001b[1;32m/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb Cell 41\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m out \u001b[39m=\u001b[39m launch(\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m     top_level_class_config, \n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m     launch_and_instantiate, \n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m     overrides\u001b[39m=\u001b[39;49m[\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class=lower_level_class_4\u001b[39;49m\u001b[39m'\u001b[39;49m])\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=4'>5</a>\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
+      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/_launch.py:251\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    250\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> 251\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    252\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    253\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    254\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    255\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    256\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    257\u001b[0m )\n\u001b[1;32m    259\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    260\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    261\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    262\u001b[0m )\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    576\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    577\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    578\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    583\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    584\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    585\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    586\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    587\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    591\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    592\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 594\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    595\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    596\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    597\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    598\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    599\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    600\u001b[0m     )\n\u001b[1;32m    601\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    602\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:142\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    133\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    134\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    135\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    139\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    140\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    141\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 142\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    143\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    144\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    145\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    146\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    147\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    148\u001b[0m         )\n\u001b[1;32m    149\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    150\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:253\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39mif\u001b[39;00m validate_sweep_overrides:\n\u001b[1;32m    249\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mvalidate_sweep_overrides_legal(\n\u001b[1;32m    250\u001b[0m         overrides\u001b[39m=\u001b[39mparsed_overrides, run_mode\u001b[39m=\u001b[39mrun_mode, from_shell\u001b[39m=\u001b[39mfrom_shell\n\u001b[1;32m    251\u001b[0m     )\n\u001b[0;32m--> 253\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    254\u001b[0m     repo\u001b[39m=\u001b[39;49mcaching_repo,\n\u001b[1;32m    255\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    256\u001b[0m     overrides_list\u001b[39m=\u001b[39;49mparsed_overrides,\n\u001b[1;32m    257\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    258\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mrun_mode \u001b[39m==\u001b[39;49m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    259\u001b[0m )\n\u001b[1;32m    261\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[1;32m    263\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_compose_config_from_defaults_list(\n\u001b[1;32m    264\u001b[0m     defaults\u001b[39m=\u001b[39mdefaults_list\u001b[39m.\u001b[39mdefaults, repo\u001b[39m=\u001b[39mcaching_repo\n\u001b[1;32m    265\u001b[0m )\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:746\u001b[0m, in \u001b[0;36mcreate_defaults_list\u001b[0;34m(repo, config_name, overrides_list, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    737\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    738\u001b[0m \u001b[39m:param repo:\u001b[39;00m\n\u001b[1;32m    739\u001b[0m \u001b[39m:param config_name:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    743\u001b[0m \u001b[39m:return:\u001b[39;00m\n\u001b[1;32m    744\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    745\u001b[0m overrides \u001b[39m=\u001b[39m Overrides(repo\u001b[39m=\u001b[39mrepo, overrides_list\u001b[39m=\u001b[39moverrides_list)\n\u001b[0;32m--> 746\u001b[0m defaults, tree \u001b[39m=\u001b[39m _create_defaults_list(\n\u001b[1;32m    747\u001b[0m     repo,\n\u001b[1;32m    748\u001b[0m     config_name,\n\u001b[1;32m    749\u001b[0m     overrides,\n\u001b[1;32m    750\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49mprepend_hydra,\n\u001b[1;32m    751\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    752\u001b[0m )\n\u001b[1;32m    753\u001b[0m overrides\u001b[39m.\u001b[39mensure_overrides_used()\n\u001b[1;32m    754\u001b[0m overrides\u001b[39m.\u001b[39mensure_deletions_used()\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:716\u001b[0m, in \u001b[0;36m_create_defaults_list\u001b[0;34m(repo, config_name, overrides, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    706\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_create_defaults_list\u001b[39m(\n\u001b[1;32m    707\u001b[0m     repo: IConfigRepository,\n\u001b[1;32m    708\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    711\u001b[0m     skip_missing: \u001b[39mbool\u001b[39m,\n\u001b[1;32m    712\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m Tuple[List[ResultDefault], DefaultsTreeNode]:\n\u001b[1;32m    714\u001b[0m     root \u001b[39m=\u001b[39m _create_root(config_name\u001b[39m=\u001b[39mconfig_name, with_hydra\u001b[39m=\u001b[39mprepend_hydra)\n\u001b[0;32m--> 716\u001b[0m     defaults_tree \u001b[39m=\u001b[39m _create_defaults_tree(\n\u001b[1;32m    717\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    718\u001b[0m         root\u001b[39m=\u001b[39;49mroot,\n\u001b[1;32m    719\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    720\u001b[0m         is_root_config\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    721\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    722\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    723\u001b[0m     )\n\u001b[1;32m    725\u001b[0m     output \u001b[39m=\u001b[39m _tree_to_list(tree\u001b[39m=\u001b[39mdefaults_tree)\n\u001b[1;32m    726\u001b[0m     ensure_no_duplicates_in_list(output)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:356\u001b[0m, in \u001b[0;36m_create_defaults_tree\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    348\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_create_defaults_tree\u001b[39m(\n\u001b[1;32m    349\u001b[0m     repo: IConfigRepository,\n\u001b[1;32m    350\u001b[0m     root: DefaultsTreeNode,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    354\u001b[0m     overrides: Overrides,\n\u001b[1;32m    355\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DefaultsTreeNode:\n\u001b[0;32m--> 356\u001b[0m     ret \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    357\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    358\u001b[0m         root\u001b[39m=\u001b[39;49mroot,\n\u001b[1;32m    359\u001b[0m         is_root_config\u001b[39m=\u001b[39;49mis_root_config,\n\u001b[1;32m    360\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    361\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49minterpolated_subtree,\n\u001b[1;32m    362\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    363\u001b[0m     )\n\u001b[1;32m    365\u001b[0m     \u001b[39mreturn\u001b[39;00m ret\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:457\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    455\u001b[0m \u001b[39mif\u001b[39;00m parent\u001b[39m.\u001b[39mis_virtual():\n\u001b[1;32m    456\u001b[0m     \u001b[39mif\u001b[39;00m is_root_config:\n\u001b[0;32m--> 457\u001b[0m         \u001b[39mreturn\u001b[39;00m _expand_virtual_root(repo, root, overrides, skip_missing)\n\u001b[1;32m    458\u001b[0m     \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    459\u001b[0m         \u001b[39mreturn\u001b[39;00m root\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:280\u001b[0m, in \u001b[0;36m_expand_virtual_root\u001b[0;34m(repo, root, overrides, skip_missing)\u001b[0m\n\u001b[1;32m    277\u001b[0m new_root \u001b[39m=\u001b[39m DefaultsTreeNode(node\u001b[39m=\u001b[39md, parent\u001b[39m=\u001b[39mroot)\n\u001b[1;32m    278\u001b[0m d\u001b[39m.\u001b[39mupdate_parent(\u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m--> 280\u001b[0m subtree \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    281\u001b[0m     repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    282\u001b[0m     root\u001b[39m=\u001b[39;49mnew_root,\n\u001b[1;32m    283\u001b[0m     is_root_config\u001b[39m=\u001b[39;49md\u001b[39m.\u001b[39;49mprimary,\n\u001b[1;32m    284\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    285\u001b[0m     interpolated_subtree\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    286\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    287\u001b[0m )\n\u001b[1;32m    288\u001b[0m \u001b[39mif\u001b[39;00m subtree\u001b[39m.\u001b[39mchildren \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    289\u001b[0m     children\u001b[39m.\u001b[39mappend(d)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:573\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    570\u001b[0m                 \u001b[39mcontinue\u001b[39;00m\n\u001b[1;32m    572\u001b[0m             new_root \u001b[39m=\u001b[39m DefaultsTreeNode(node\u001b[39m=\u001b[39md, parent\u001b[39m=\u001b[39mroot)\n\u001b[0;32m--> 573\u001b[0m             add_child(children, new_root)\n\u001b[1;32m    575\u001b[0m \u001b[39m# processed deferred interpolations\u001b[39;00m\n\u001b[1;32m    576\u001b[0m known_choices \u001b[39m=\u001b[39m _create_interpolation_map(overrides, defaults_list, self_added)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:520\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl.<locals>.add_child\u001b[0;34m(child_list, new_root_)\u001b[0m\n\u001b[1;32m    516\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39madd_child\u001b[39m(\n\u001b[1;32m    517\u001b[0m     child_list: List[Union[InputDefault, DefaultsTreeNode]],\n\u001b[1;32m    518\u001b[0m     new_root_: DefaultsTreeNode,\n\u001b[1;32m    519\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 520\u001b[0m     subtree_ \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    521\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    522\u001b[0m         root\u001b[39m=\u001b[39;49mnew_root_,\n\u001b[1;32m    523\u001b[0m         is_root_config\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    524\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49minterpolated_subtree,\n\u001b[1;32m    525\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    526\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    527\u001b[0m     )\n\u001b[1;32m    528\u001b[0m     \u001b[39mif\u001b[39;00m subtree_\u001b[39m.\u001b[39mchildren \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    529\u001b[0m         child_list\u001b[39m.\u001b[39mappend(new_root_\u001b[39m.\u001b[39mnode)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:488\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    486\u001b[0m         parent\u001b[39m.\u001b[39mdeleted \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n\u001b[1;32m    487\u001b[0m         \u001b[39mreturn\u001b[39;00m root\n\u001b[0;32m--> 488\u001b[0m     config_not_found_error(repo\u001b[39m=\u001b[39;49mrepo, tree\u001b[39m=\u001b[39;49mroot)\n\u001b[1;32m    490\u001b[0m \u001b[39massert\u001b[39;00m loaded \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    491\u001b[0m defaults_list \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(loaded\u001b[39m.\u001b[39mdefaults_list)\n",
+      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:800\u001b[0m, in \u001b[0;36mconfig_not_found_error\u001b[0;34m(repo, tree)\u001b[0m\n\u001b[1;32m    797\u001b[0m lines \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39mjoin(descs)\n\u001b[1;32m    798\u001b[0m msg \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39mConfig search path:\u001b[39m\u001b[39m\"\u001b[39m \u001b[39m+\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00mlines\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 800\u001b[0m \u001b[39mraise\u001b[39;00m MissingConfigException(\n\u001b[1;32m    801\u001b[0m     missing_cfg_file\u001b[39m=\u001b[39melement\u001b[39m.\u001b[39mget_config_path(),\n\u001b[1;32m    802\u001b[0m     message\u001b[39m=\u001b[39mmsg,\n\u001b[1;32m    803\u001b[0m     options\u001b[39m=\u001b[39moptions,\n\u001b[1;32m    804\u001b[0m )\n",
+      "\u001b[0;31mMissingConfigException\u001b[0m: In 'zen_launch': Could not find 'lower_level_class/lower_level_class_3'\n\nConfig search path:\n\tprovider=hydra, path=pkg://hydra.conf\n\tprovider=schema, path=structured://"
+     ]
     }
    ],
    "source": [
@@ -883,11 +916,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 54,
    "metadata": {},
    "outputs": [],
    "source": [
-    "@add_conf\n",
+    "@add_batteries\n",
     "class TopLevelClass:\n",
     "    def __init__(\n",
     "        self,\n",
@@ -901,7 +934,7 @@
     "    def __repr__(self):\n",
     "        return f'TopLevelClass({self.a}, {self.mid_level_class})'\n",
     "\n",
-    "@add_conf(group_='mlc_group')   \n",
+    "@add_batteries(group_='mlc_group')   \n",
     "class MidLevelClass:\n",
     "    def __init__(\n",
     "        self,\n",
@@ -914,7 +947,7 @@
     "    def __repr__(self):\n",
     "        return f'MidLevelClass({self.b}, {self.lower_level_class})'\n",
     "        \n",
-    "@add_conf(group_='llc_group')        \n",
+    "@add_batteries(group_='llc_group')        \n",
     "class LowerLevelClass:\n",
     "    def __init__(\n",
     "        self,\n",
@@ -929,7 +962,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 59,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -938,7 +971,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), c='type 1', name_='llc_1', group_='llc_group', package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 59,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -969,19 +1002,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 56,
    "metadata": {},
    "outputs": [
     {
-     "ename": "NameError",
-     "evalue": "name 'delete_keys_from_dict' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[60], line 28\u001b[0m\n\u001b[1;32m     16\u001b[0m mlc_3 \u001b[39m=\u001b[39m MidLevelClass\u001b[39m.\u001b[39mConf(\n\u001b[1;32m     17\u001b[0m     b \u001b[39m=\u001b[39m \u001b[39m3\u001b[39m,\n\u001b[1;32m     18\u001b[0m     lower_level_class\u001b[39m=\u001b[39mMISSING,\n\u001b[1;32m     19\u001b[0m     name_\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mmlc_3\u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     20\u001b[0m )\n\u001b[1;32m     22\u001b[0m mlc_4 \u001b[39m=\u001b[39m MidLevelClass\u001b[39m.\u001b[39mConf(\n\u001b[1;32m     23\u001b[0m     b \u001b[39m=\u001b[39m \u001b[39m4\u001b[39m,\n\u001b[1;32m     24\u001b[0m     lower_level_class\u001b[39m=\u001b[39mllc_4,\n\u001b[1;32m     25\u001b[0m     name_\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mmlc_4\u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     26\u001b[0m )\n\u001b[0;32m---> 28\u001b[0m mlc_1\u001b[39m.\u001b[39;49mshow()\n",
-      "File \u001b[0;32m~/loyal/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:445\u001b[0m, in \u001b[0;36mZenExtras.show\u001b[0;34m(self, verbosity, exclude_keys, *args, **kwargs)\u001b[0m\n\u001b[1;32m    443\u001b[0m \u001b[39melif\u001b[39;00m verbosity \u001b[39m==\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mcompact\u001b[39m\u001b[39m\"\u001b[39m:\n\u001b[1;32m    444\u001b[0m     d \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mto_dict()\n\u001b[0;32m--> 445\u001b[0m     delete_keys_from_dict(d, exclude_keys)\n\u001b[1;32m    446\u001b[0m     delete_null_cs_keys(d)\n\u001b[1;32m    447\u001b[0m     delete_null_vals_from_dict(d)\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'delete_keys_from_dict' is not defined"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_zen_target: __main__.MidLevelClass\n",
+      "b: 1\n",
+      "lower_level_class: ???\n",
+      "name_: mlc_1\n",
+      "group_: mlc_group\n",
+      "defaults:\n",
+      "- /llc_group@lower_level_class: llc_3\n",
+      "\n"
      ]
     }
    ],
@@ -1018,7 +1053,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 57,
    "metadata": {},
    "outputs": [
     {
@@ -1052,20 +1087,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "TopLevelClass(123, MidLevelClass(1, LowerLevelClass(type 3)))"
-      ]
-     },
-     "execution_count": 47,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "out = launch(\n",
     "    tlc_1, \n",
@@ -1076,20 +1100,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "TopLevelClass(123, MidLevelClass(1, LowerLevelClass(type 3)))"
-      ]
-     },
-     "execution_count": 48,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "out = launch(\n",
     "    tlc_1, \n",
@@ -1126,27 +1139,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ConfigCompositionException",
-     "evalue": "Could not override 'llc_group@lower_level_class'.\nDid you mean to override llc_group@mid_level_class.lower_level_class?\nTo append to your default list use +llc_group@lower_level_class=llc_2",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mConfigCompositionException\u001b[0m                Traceback (most recent call last)",
-      "\u001b[1;32m/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb Cell 46'\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=0'>1</a>\u001b[0m out \u001b[39m=\u001b[39m launch(\n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=1'>2</a>\u001b[0m     tlc_1, \n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=2'>3</a>\u001b[0m     launch_and_instantiate, \n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=3'>4</a>\u001b[0m     overrides\u001b[39m=\u001b[39;49m[\u001b[39m'\u001b[39;49m\u001b[39mllc_group@lower_level_class=llc_2\u001b[39;49m\u001b[39m'\u001b[39;49m]\n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=4'>5</a>\u001b[0m     )\n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=5'>6</a>\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
-      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py:246\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=242'>243</a>\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=244'>245</a>\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=245'>246</a>\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=246'>247</a>\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=247'>248</a>\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=248'>249</a>\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=249'>250</a>\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=250'>251</a>\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=251'>252</a>\u001b[0m )\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=253'>254</a>\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=254'>255</a>\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=255'>256</a>\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=256'>257</a>\u001b[0m )\n",
-      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=575'>576</a>\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=576'>577</a>\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=577'>578</a>\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=582'>583</a>\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=583'>584</a>\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=584'>585</a>\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=585'>586</a>\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=586'>587</a>\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=590'>591</a>\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=591'>592</a>\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=593'>594</a>\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=594'>595</a>\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=595'>596</a>\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=596'>597</a>\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=597'>598</a>\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=598'>599</a>\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=599'>600</a>\u001b[0m     )\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=600'>601</a>\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=601'>602</a>\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
-      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py:141\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=131'>132</a>\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=132'>133</a>\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=133'>134</a>\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=137'>138</a>\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=138'>139</a>\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=139'>140</a>\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=140'>141</a>\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=141'>142</a>\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=142'>143</a>\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=143'>144</a>\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=144'>145</a>\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=145'>146</a>\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=146'>147</a>\u001b[0m         )\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=147'>148</a>\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=148'>149</a>\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py:242\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=236'>237</a>\u001b[0m \u001b[39mif\u001b[39;00m validate_sweep_overrides:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=237'>238</a>\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mvalidate_sweep_overrides_legal(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=238'>239</a>\u001b[0m         overrides\u001b[39m=\u001b[39mparsed_overrides, run_mode\u001b[39m=\u001b[39mrun_mode, from_shell\u001b[39m=\u001b[39mfrom_shell\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=239'>240</a>\u001b[0m     )\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=241'>242</a>\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=242'>243</a>\u001b[0m     repo\u001b[39m=\u001b[39;49mcaching_repo,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=243'>244</a>\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=244'>245</a>\u001b[0m     overrides_list\u001b[39m=\u001b[39;49mparsed_overrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=245'>246</a>\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=246'>247</a>\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mrun_mode \u001b[39m==\u001b[39;49m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=247'>248</a>\u001b[0m )\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=249'>250</a>\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=251'>252</a>\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_compose_config_from_defaults_list(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=252'>253</a>\u001b[0m     defaults\u001b[39m=\u001b[39mdefaults_list\u001b[39m.\u001b[39mdefaults, repo\u001b[39m=\u001b[39mcaching_repo\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=253'>254</a>\u001b[0m )\n",
-      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py:757\u001b[0m, in \u001b[0;36mcreate_defaults_list\u001b[0;34m(repo, config_name, overrides_list, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=748'>749</a>\u001b[0m overrides \u001b[39m=\u001b[39m Overrides(repo\u001b[39m=\u001b[39mrepo, overrides_list\u001b[39m=\u001b[39moverrides_list)\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=749'>750</a>\u001b[0m defaults, tree \u001b[39m=\u001b[39m _create_defaults_list(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=750'>751</a>\u001b[0m     repo,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=751'>752</a>\u001b[0m     config_name,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=754'>755</a>\u001b[0m     skip_missing\u001b[39m=\u001b[39mskip_missing,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=755'>756</a>\u001b[0m )\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=756'>757</a>\u001b[0m overrides\u001b[39m.\u001b[39;49mensure_overrides_used()\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=757'>758</a>\u001b[0m overrides\u001b[39m.\u001b[39mensure_deletions_used()\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=758'>759</a>\u001b[0m \u001b[39mreturn\u001b[39;00m DefaultsList(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=759'>760</a>\u001b[0m     defaults\u001b[39m=\u001b[39mdefaults,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=760'>761</a>\u001b[0m     config_overrides\u001b[39m=\u001b[39moverrides\u001b[39m.\u001b[39mconfig_overrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=761'>762</a>\u001b[0m     defaults_tree\u001b[39m=\u001b[39mtree,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=762'>763</a>\u001b[0m     overrides\u001b[39m=\u001b[39moverrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=763'>764</a>\u001b[0m )\n",
-      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py:168\u001b[0m, in \u001b[0;36mOverrides.ensure_overrides_used\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=164'>165</a>\u001b[0m \u001b[39mif\u001b[39;00m meta\u001b[39m.\u001b[39mexternal_override:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=165'>166</a>\u001b[0m     msg \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39mTo append to your default list use +\u001b[39m\u001b[39m{\u001b[39;00mkey\u001b[39m}\u001b[39;00m\u001b[39m=\u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39moverride_choices[key]\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=167'>168</a>\u001b[0m \u001b[39mraise\u001b[39;00m ConfigCompositionException(msg)\n",
-      "\u001b[0;31mConfigCompositionException\u001b[0m: Could not override 'llc_group@lower_level_class'.\nDid you mean to override llc_group@mid_level_class.lower_level_class?\nTo append to your default list use +llc_group@lower_level_class=llc_2"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "out = launch(\n",
     "    tlc_1, \n",
@@ -1165,9 +1160,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 80,
+   "execution_count": 60,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "__init__() got an unexpected keyword argument 'b'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb Cell 52\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m \u001b[39mwith\u001b[39;00m ConfMode():\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m     LowerLevelClass(\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m         name_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class_5\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m         group_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=4'>5</a>\u001b[0m         b\u001b[39m=\u001b[39;49m\u001b[39m117\u001b[39;49m,\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=5'>6</a>\u001b[0m     )\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=6'>7</a>\u001b[0m     top_level_class_config_2 \u001b[39m=\u001b[39m TopLevelClass(\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=7'>8</a>\u001b[0m         a\u001b[39m=\u001b[39m\u001b[39m-\u001b[39m\u001b[39m9\u001b[39m,\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=8'>9</a>\u001b[0m         name_\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mtop_level_class_2\u001b[39m\u001b[39m'\u001b[39m, \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=11'>12</a>\u001b[0m             {\u001b[39m'\u001b[39m\u001b[39mlower_level_class\u001b[39m\u001b[39m'\u001b[39m: \u001b[39m'\u001b[39m\u001b[39mlower_level_class_5\u001b[39m\u001b[39m'\u001b[39m}]\n\u001b[1;32m     <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=12'>13</a>\u001b[0m     )\n",
+      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:518\u001b[0m, in \u001b[0;36m_batteries_included_override_constructor.<locals>.WrappedClass.__new__\u001b[0;34m(cls, name_, group_, package_, provider_, defaults, *args, **kwargs)\u001b[0m\n\u001b[1;32m    516\u001b[0m \u001b[39mglobal\u001b[39;00m _configuring\n\u001b[1;32m    517\u001b[0m \u001b[39mif\u001b[39;00m _configuring:\n\u001b[0;32m--> 518\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mcls\u001b[39;49m\u001b[39m.\u001b[39;49mConf(\u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mzen_meta, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    519\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    520\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39msuper\u001b[39m(WrappedClass, \u001b[39mcls\u001b[39m)\u001b[39m.\u001b[39m\u001b[39m__new__\u001b[39m(\u001b[39mcls\u001b[39m)\n",
+      "\u001b[0;31mTypeError\u001b[0m: __init__() got an unexpected keyword argument 'b'"
+     ]
+    }
+   ],
    "source": [
     "with ConfMode():\n",
     "    LowerLevelClass(\n",
@@ -1290,13 +1298,13 @@
    "outputs": [],
    "source": [
     "# setup conf for torch primitives\n",
-    "Linear = add_conf(nn.Linear)\n",
-    "LazyLinear = add_conf(nn.LazyLinear)\n",
-    "ReLU = add_conf(nn.ReLU)\n",
-    "Dropout = add_conf(nn.Dropout)\n",
-    "BatchNorm = add_conf(nn.BatchNorm1d)\n",
-    "Identity = add_conf(nn.Identity)\n",
-    "Module = add_conf(nn.Module)"
+    "Linear = add_batteries(nn.Linear)\n",
+    "LazyLinear = add_batteries(nn.LazyLinear)\n",
+    "ReLU = add_batteries(nn.ReLU)\n",
+    "Dropout = add_batteries(nn.Dropout)\n",
+    "BatchNorm = add_batteries(nn.BatchNorm1d)\n",
+    "Identity = add_batteries(nn.Identity)\n",
+    "Module = add_batteries(nn.Module)"
    ]
   },
   {
@@ -1891,7 +1899,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "hydra-zen",
+   "display_name": "newtricks",
    "language": "python",
    "name": "python3"
   },
@@ -1905,12 +1913,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8"
+   "version": "3.8.5"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "08e26d46b7b4f1fdfcdd4d684abaf70b6007d139442080e1d602d0a21496e18e"
+    "hash": "f2b5ce3424cfe828ef4e1c95261b27483fb5e8064e6ac1b9427b271ef41a820d"
    }
   }
  },

--- a/ipynb/add_conf_demo.ipynb
+++ b/ipynb/add_conf_demo.ipynb
@@ -1,0 +1,1842 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/loyal/newtricks/data_sci_utils/data_sci_utils/hydra_zen.py:292: HydraZenDeprecationWarning: Specifying `make_custom_builds_fn(builds_bases=<...>)` is deprecated as of hydra-zen 0.7.0. It will be an error in hydra-zen 0.8.0. \n",
+      "`builds_bases` must be specified via `builds` manually.\n",
+      "  configures = make_custom_builds_fn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "from data_sci_utils.hydra_zen import add_conf, cs, zen_dry_run, launch_and_instantiate, add_func_conf, ConfMode, _add_conf\n",
+    "from hydra_zen import launch\n",
+    "from typing import Any, List\n",
+    "from omegaconf import MISSING\n",
+    "import pandas as pd\n",
+    "%load_ext autoreload \n",
+    "%autoreload 2\n",
+    "%config Completer.use_jedi = False"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# using `add_conf`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## decorate a newly defined class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyClass(dog, 3)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "@add_conf(hydra_recursive=False)\n",
+    "class MyClass:\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        a:str='dog', \n",
+    "        b:int=3,\n",
+    "        ):\n",
+    "        self.a = a\n",
+    "        self.b = b\n",
+    "        \n",
+    "    def __repr__(self):\n",
+    "        return f'MyClass({self.a}, {self.b})'\n",
+    "    \n",
+    "MyClass()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "types.Builds_MyClass"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# class object has a configuration dataclass attached as .Conf attribute\n",
+    "MyClass.Conf # .Conf attribute is a class object (not an instance)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='dog', b=3, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# you can use .Conf just like a class method\n",
+    "# e.g. instantiate a config dataclass with default objects\n",
+    "MyClass.Conf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# e.g. instantiate a config dataclass with non default arguments\n",
+    "MyClass.Conf(a='Bloom', b=999)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyClass(dog, 3)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# instantiate a config dataclass with default objects, then use it to instantiate parent class\n",
+    "MyClass.Conf().instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyClass(Bloom, 3)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# instantiate a config dataclass with non default arguments, then use it to instantiate parent class\n",
+    "MyClass.Conf(a='Bloom').instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# normal constructor \n",
+    "my_class = MyClass(a='Bloom', b=999)\n",
+    "\n",
+    "# the my_class instance has a .conf attribute\n",
+    "# this is different from .Conf because\n",
+    "# 1) it is an instance variable and\n",
+    "# 2) it is an instantiated dataclass object\n",
+    "# it is the Conf instance that builds this instance of MyClass\n",
+    "my_class.conf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyClass(Lily, 3)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# starting with config\n",
+    "MyClass.Conf(a='Lily').instantiate().conf.instantiate().conf.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyClass(Lily, 3)"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# starting with regular constructor\n",
+    "MyClass(a='Lily').conf.instantiate().conf.instantiate().conf.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyClass(Bloom, 47)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# editing a config\n",
+    "my_class_conf = MyClass.Conf(a='Lily',b=47)\n",
+    "my_class_conf.a = 'Bloom'\n",
+    "my_class_conf.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "MyClass(Bloom, 117)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# you can call .conf as well and provide new values for a subset of inputs\n",
+    "my_class = MyClass(a='Lily', b=117)\n",
+    "my_class_bloom = my_class.conf(a=\"Bloom\")\n",
+    "my_class_bloom.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## wrap an existing class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn.linear_model import LogisticRegression\n",
+    "WrappedLogisticRegression = add_conf(LogisticRegression)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_zen_target: sklearn.linear_model._logistic.LogisticRegression\n",
+      "penalty: l2\n",
+      "dual: false\n",
+      "tol: 0.0001\n",
+      "C: 1.0\n",
+      "fit_intercept: true\n",
+      "intercept_scaling: 1\n",
+      "solver: lbfgs\n",
+      "max_iter: 100\n",
+      "multi_class: auto\n",
+      "verbose: 0\n",
+      "warm_start: false\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# conf attr has fully populated fields\n",
+    "WrappedLogisticRegression.Conf().show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<style>#sk-container-id-1 {color: black;background-color: white;}#sk-container-id-1 pre{padding: 0;}#sk-container-id-1 div.sk-toggleable {background-color: white;}#sk-container-id-1 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-1 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-1 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-1 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-1 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-1 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-1 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-1 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-1 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-1 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-1 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-1 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-1 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-1 div.sk-item {position: relative;z-index: 1;}#sk-container-id-1 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-1 div.sk-item::before, #sk-container-id-1 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-1 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-1 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-1 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-1 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-1 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-1 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-1 div.sk-label-container {text-align: center;}#sk-container-id-1 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-1 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-1\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>LogisticRegression(penalty=&#x27;l1&#x27;)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-1\" type=\"checkbox\" checked><label for=\"sk-estimator-id-1\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">LogisticRegression</label><div class=\"sk-toggleable__content\"><pre>LogisticRegression(penalty=&#x27;l1&#x27;)</pre></div></div></div></div></div>"
+      ],
+      "text/plain": [
+       "LogisticRegression(penalty='l1')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# can be used to instantiate\n",
+    "WrappedLogisticRegression.Conf(penalty='l1', C=1.0).instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/torch/nn/modules/lazy.py:178: UserWarning: Lazy modules are a new feature under heavy development so changes to the API or functionality can happen at any moment.\n",
+      "  warnings.warn('Lazy modules are a new feature under heavy development '\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "LazyLinear(in_features=0, out_features=2, bias=True)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# another example\n",
+    "from torch import nn\n",
+    "LazyLinear = add_conf(nn.LazyLinear)\n",
+    "LazyLinear.Conf(out_features=2).instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_LogisticRegression(_target_='hydra_zen.funcs.zen_processing', _zen_target='sklearn.linear_model._logistic.LogisticRegression', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), penalty='l2', dual=False, tol=0.0001, C=1.0, fit_intercept=True, intercept_scaling=1, class_weight=None, random_state=None, solver='lbfgs', max_iter=100, multi_class='auto', verbose=0, warm_start=False, n_jobs=None, l1_ratio=None, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# can overwrite imports, this might be sus but could be useful for backwards compatibility\n",
+    "LogisticRegression = add_conf(LogisticRegression)\n",
+    "LogisticRegression.Conf()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# idempotent\n",
+    "LogisticRegression = add_conf(add_conf(add_conf(add_conf(add_conf(LogisticRegression)))))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## working with functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# works the same as above - gives function a .conf attribute\n",
+    "# does not work with positional arguments - you need some kind of default value, even if it is None or MISSING\n",
+    "# by default this returns a partial\n",
+    "@add_func_conf\n",
+    "def add_numbers(a:int=MISSING, b:int=MISSING):\n",
+    "    return a + b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "3"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "add_numbers.Conf(a=1, b=2).instantiate()()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# add_func_conf lets you change settings being used in hydra_zen.builds under the hood\n",
+    "# here we make it so that the function is not wrapped in a partial\n",
+    "@add_func_conf(zen_partial=False)\n",
+    "def make_dataframe():\n",
+    "    return pd.DataFrame({'a': 1}, index=[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>a</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   a\n",
+       "0  1"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# now instantiation just immediately returns the dataframe\n",
+    "make_dataframe.Conf().instantiate()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## creating and storing named configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@add_conf\n",
+    "class TopLevelClass:\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        a:int = 0,\n",
+    "        lower_level_class: Any = MISSING,\n",
+    "        **kwargs,\n",
+    "        ):\n",
+    "        self.a = a\n",
+    "        self.lower_level_class = lower_level_class\n",
+    "        \n",
+    "    def __repr__(self):\n",
+    "        return f'TopLevelClass({self.a}, {self.lower_level_class})'\n",
+    "        \n",
+    "@add_conf        \n",
+    "class LowerLevelClass:\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        b: str = 'hello',\n",
+    "        **kwargs,\n",
+    "    ):\n",
+    "        self.b = b\n",
+    "\n",
+    "    def __repr__(self):\n",
+    "        return f'LowerLevelClass({self.b})'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "LowerLevelClass(hello)"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# decorated classes will accept name_, group_, and defaults as arguments\n",
+    "lower_level_class = LowerLevelClass(\n",
+    "    name_='lower_level_class_1',\n",
+    "    )\n",
+    "lower_level_class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['_dummy_empty_config_.yaml', 'hydra', 'lower_level_class_1.yaml']"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# constructing a decorated class with a name_ argument will automatically store it in ConfigStore\n",
+    "cs.list('')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b=99, name_='lower_level_class_2', group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# constructing the .conf dataclass with a name_ argument will also automatically store it in ConfigStore\n",
+    "LowerLevelClass.Conf(\n",
+    "    name_='lower_level_class_2',\n",
+    "    b=99,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['_dummy_empty_config_.yaml',\n",
+       " 'hydra',\n",
+       " 'lower_level_class_1.yaml',\n",
+       " 'lower_level_class_2.yaml']"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cs.list('')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b=99, name_='lower_level_class_4', group_='lower_level_class', package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# config group names can be set in the same manner\n",
+    "LowerLevelClass(\n",
+    "    name_='lower_level_class_3',\n",
+    "    group_='lower_level_class',\n",
+    "    )\n",
+    "\n",
+    "LowerLevelClass.Conf(\n",
+    "    name_='lower_level_class_4',\n",
+    "    group_='lower_level_class',\n",
+    "    b=99,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b='hello', name_='lower_level_class_3', group_='lower_level_class', package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "LowerLevelClass(\n",
+    "    name_='lower_level_class_3',\n",
+    "    group_='lower_level_class',\n",
+    "    ).conf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# as can the defaults list\n",
+    "top_level_class_config = TopLevelClass.Conf(\n",
+    "    name_='top_level_class', \n",
+    "    defaults=['_self_', {'lower_level_class': 'lower_level_class_3'}]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py:235: UserWarning: \n",
+      "The version_base parameter is not specified.\n",
+      "Please specify a compatability version level, or None.\n",
+      "Will assume defaults for version 1.1\n",
+      "  with initialize(\n",
+      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_3': Usage of deprecated keyword in package header '# @package _group_'.\n",
+      "See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
+      "  deprecation_warning(\n",
+      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py:265: UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.\n",
+      "See https://hydra.cc/docs/next/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information.\n",
+      "  job = run_job(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(0, LowerLevelClass(hello))"
+      ]
+     },
+     "execution_count": 31,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out = launch(top_level_class_config, launch_and_instantiate)\n",
+    "out.return_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py:235: UserWarning: \n",
+      "The version_base parameter is not specified.\n",
+      "Please specify a compatability version level, or None.\n",
+      "Will assume defaults for version 1.1\n",
+      "  with initialize(\n",
+      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_4': Usage of deprecated keyword in package header '# @package _group_'.\n",
+      "See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
+      "  deprecation_warning(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(0, LowerLevelClass(99))"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out = launch(\n",
+    "    top_level_class_config, \n",
+    "    launch_and_instantiate, \n",
+    "    overrides=['lower_level_class=lower_level_class_4'])\n",
+    "out.return_value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### let's look at more complex configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "@add_conf\n",
+    "class TopLevelClass:\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        a:int = 0,\n",
+    "        mid_level_class: Any = MISSING,\n",
+    "        **kwargs,\n",
+    "    ):\n",
+    "        self.a = a\n",
+    "        self.mid_level_class = mid_level_class\n",
+    "        \n",
+    "    def __repr__(self):\n",
+    "        return f'TopLevelClass({self.a}, {self.mid_level_class})'\n",
+    "\n",
+    "@add_conf(group_='mlc_group')   \n",
+    "class MidLevelClass:\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        b:int = 0,\n",
+    "        lower_level_class: Any = MISSING\n",
+    "    ):\n",
+    "        self.b = b\n",
+    "        self.lower_level_class = lower_level_class\n",
+    "\n",
+    "    def __repr__(self):\n",
+    "        return f'MidLevelClass({self.b}, {self.lower_level_class})'\n",
+    "        \n",
+    "@add_conf(group_='llc_group')        \n",
+    "class LowerLevelClass:\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        c: str = 'hello',\n",
+    "        **kwargs,\n",
+    "    ):\n",
+    "        self.c = c\n",
+    "\n",
+    "    def __repr__(self):\n",
+    "        return f'LowerLevelClass({self.c})'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), c='type 1', name_='llc_1', group_='llc_group', package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 34,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "llc_1 = LowerLevelClass.Conf(\n",
+    "    c = 'type 1',\n",
+    "    name_='llc_1'\n",
+    ")\n",
+    "\n",
+    "llc_2 = LowerLevelClass.Conf(\n",
+    "    c = 'type 2',\n",
+    "    name_='llc_2'\n",
+    ")\n",
+    "\n",
+    "llc_3 = LowerLevelClass.Conf(\n",
+    "    c = 'type 3',\n",
+    "    name_='llc_3'\n",
+    ")\n",
+    "\n",
+    "llc_4 = LowerLevelClass.Conf(\n",
+    "    c = 'type 4',\n",
+    "    name_='llc_4'\n",
+    ")\n",
+    "\n",
+    "llc_1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_zen_target: __main__.MidLevelClass\n",
+      "b: 1\n",
+      "lower_level_class:\n",
+      "  _zen_target: __main__.LowerLevelClass\n",
+      "  c: type 3\n",
+      "  name_: llc_3\n",
+      "  group_: llc_group\n",
+      "name_: mlc_1\n",
+      "group_: mlc_group\n",
+      "defaults:\n",
+      "- /llc_group@lower_level_class: llc_3\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "mlc_1 = MidLevelClass.Conf(\n",
+    "    b = 1,\n",
+    "    lower_level_class=MISSING,\n",
+    "    name_='mlc_1',\n",
+    "    defaults=[\n",
+    "            {'/llc_group@lower_level_class': 'llc_3'},\n",
+    "        ]\n",
+    ")\n",
+    "\n",
+    "mlc_2 = MidLevelClass.Conf(\n",
+    "    b = 2,\n",
+    "    lower_level_class=MISSING,\n",
+    "    name_='mlc_2'\n",
+    ")\n",
+    "\n",
+    "mlc_3 = MidLevelClass.Conf(\n",
+    "    b = 3,\n",
+    "    lower_level_class=MISSING,\n",
+    "    name_='mlc_3'\n",
+    ")\n",
+    "\n",
+    "mlc_4 = MidLevelClass.Conf(\n",
+    "    b = 4,\n",
+    "    lower_level_class=llc_4,\n",
+    "    name_='mlc_4'\n",
+    ")\n",
+    "\n",
+    "mlc_1.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_zen_target: __main__.TopLevelClass\n",
+      "a: 123\n",
+      "mid_level_class: ???\n",
+      "name_: tlc_1\n",
+      "defaults:\n",
+      "- mlc_group@mid_level_class: mlc_1\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "tlc_1 = TopLevelClass.Conf(\n",
+    "    a = 123,\n",
+    "    mid_level_class=MISSING,\n",
+    "    name_='tlc_1',\n",
+    "    defaults=[\n",
+    "            {\n",
+    "                'mlc_group@mid_level_class': 'mlc_1',\n",
+    "            },\n",
+    "        ]\n",
+    ")\n",
+    "\n",
+    "tlc_1.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(123, MidLevelClass(1, LowerLevelClass(type 3)))"
+      ]
+     },
+     "execution_count": 47,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out = launch(\n",
+    "    tlc_1, \n",
+    "    launch_and_instantiate\n",
+    "    )\n",
+    "out.return_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(123, MidLevelClass(1, LowerLevelClass(type 3)))"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out = launch(\n",
+    "    tlc_1, \n",
+    "    launch_and_instantiate, \n",
+    "    overrides=['llc_group@mid_level_class.lower_level_class=llc_4']\n",
+    "    )\n",
+    "out.return_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(123, MidLevelClass(1, LowerLevelClass(type X)))"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out = launch(\n",
+    "    tlc_1, \n",
+    "    launch_and_instantiate, \n",
+    "    overrides=['mid_level_class.lower_level_class.c=\"type X\"']\n",
+    "    )\n",
+    "out.return_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "ConfigCompositionException",
+     "evalue": "Could not override 'llc_group@lower_level_class'.\nDid you mean to override llc_group@mid_level_class.lower_level_class?\nTo append to your default list use +llc_group@lower_level_class=llc_2",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mConfigCompositionException\u001b[0m                Traceback (most recent call last)",
+      "\u001b[1;32m/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb Cell 46'\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=0'>1</a>\u001b[0m out \u001b[39m=\u001b[39m launch(\n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=1'>2</a>\u001b[0m     tlc_1, \n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=2'>3</a>\u001b[0m     launch_and_instantiate, \n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=3'>4</a>\u001b[0m     overrides\u001b[39m=\u001b[39;49m[\u001b[39m'\u001b[39;49m\u001b[39mllc_group@lower_level_class=llc_2\u001b[39;49m\u001b[39m'\u001b[39;49m]\n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=4'>5</a>\u001b[0m     )\n\u001b[1;32m      <a href='vscode-notebook-cell://ssh-remote%2Bec2-multigpu/home/ubuntu/loyal/newtricks/thundercloud/notebooks/add_conf_demo.ipynb#ch0000045vscode-remote?line=5'>6</a>\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
+      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py:246\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=242'>243</a>\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=244'>245</a>\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=245'>246</a>\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=246'>247</a>\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=247'>248</a>\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=248'>249</a>\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=249'>250</a>\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=250'>251</a>\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=251'>252</a>\u001b[0m )\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=253'>254</a>\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=254'>255</a>\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=255'>256</a>\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py?line=256'>257</a>\u001b[0m )\n",
+      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=575'>576</a>\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=576'>577</a>\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=577'>578</a>\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=582'>583</a>\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=583'>584</a>\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=584'>585</a>\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=585'>586</a>\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=586'>587</a>\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=590'>591</a>\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=591'>592</a>\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=593'>594</a>\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=594'>595</a>\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=595'>596</a>\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=596'>597</a>\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=597'>598</a>\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=598'>599</a>\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=599'>600</a>\u001b[0m     )\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=600'>601</a>\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/hydra.py?line=601'>602</a>\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
+      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py:141\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=131'>132</a>\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=132'>133</a>\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=133'>134</a>\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=137'>138</a>\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=138'>139</a>\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=139'>140</a>\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=140'>141</a>\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=141'>142</a>\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=142'>143</a>\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=143'>144</a>\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=144'>145</a>\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=145'>146</a>\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=146'>147</a>\u001b[0m         )\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=147'>148</a>\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=148'>149</a>\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py:242\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=236'>237</a>\u001b[0m \u001b[39mif\u001b[39;00m validate_sweep_overrides:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=237'>238</a>\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mvalidate_sweep_overrides_legal(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=238'>239</a>\u001b[0m         overrides\u001b[39m=\u001b[39mparsed_overrides, run_mode\u001b[39m=\u001b[39mrun_mode, from_shell\u001b[39m=\u001b[39mfrom_shell\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=239'>240</a>\u001b[0m     )\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=241'>242</a>\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=242'>243</a>\u001b[0m     repo\u001b[39m=\u001b[39;49mcaching_repo,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=243'>244</a>\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=244'>245</a>\u001b[0m     overrides_list\u001b[39m=\u001b[39;49mparsed_overrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=245'>246</a>\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=246'>247</a>\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mrun_mode \u001b[39m==\u001b[39;49m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=247'>248</a>\u001b[0m )\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=249'>250</a>\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=251'>252</a>\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_compose_config_from_defaults_list(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=252'>253</a>\u001b[0m     defaults\u001b[39m=\u001b[39mdefaults_list\u001b[39m.\u001b[39mdefaults, repo\u001b[39m=\u001b[39mcaching_repo\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/config_loader_impl.py?line=253'>254</a>\u001b[0m )\n",
+      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py:757\u001b[0m, in \u001b[0;36mcreate_defaults_list\u001b[0;34m(repo, config_name, overrides_list, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=748'>749</a>\u001b[0m overrides \u001b[39m=\u001b[39m Overrides(repo\u001b[39m=\u001b[39mrepo, overrides_list\u001b[39m=\u001b[39moverrides_list)\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=749'>750</a>\u001b[0m defaults, tree \u001b[39m=\u001b[39m _create_defaults_list(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=750'>751</a>\u001b[0m     repo,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=751'>752</a>\u001b[0m     config_name,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=754'>755</a>\u001b[0m     skip_missing\u001b[39m=\u001b[39mskip_missing,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=755'>756</a>\u001b[0m )\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=756'>757</a>\u001b[0m overrides\u001b[39m.\u001b[39;49mensure_overrides_used()\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=757'>758</a>\u001b[0m overrides\u001b[39m.\u001b[39mensure_deletions_used()\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=758'>759</a>\u001b[0m \u001b[39mreturn\u001b[39;00m DefaultsList(\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=759'>760</a>\u001b[0m     defaults\u001b[39m=\u001b[39mdefaults,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=760'>761</a>\u001b[0m     config_overrides\u001b[39m=\u001b[39moverrides\u001b[39m.\u001b[39mconfig_overrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=761'>762</a>\u001b[0m     defaults_tree\u001b[39m=\u001b[39mtree,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=762'>763</a>\u001b[0m     overrides\u001b[39m=\u001b[39moverrides,\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=763'>764</a>\u001b[0m )\n",
+      "File \u001b[0;32m~/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py:168\u001b[0m, in \u001b[0;36mOverrides.ensure_overrides_used\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=164'>165</a>\u001b[0m \u001b[39mif\u001b[39;00m meta\u001b[39m.\u001b[39mexternal_override:\n\u001b[1;32m    <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=165'>166</a>\u001b[0m     msg \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39mTo append to your default list use +\u001b[39m\u001b[39m{\u001b[39;00mkey\u001b[39m}\u001b[39;00m\u001b[39m=\u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39moverride_choices[key]\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> <a href='file:///home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/_internal/defaults_list.py?line=167'>168</a>\u001b[0m \u001b[39mraise\u001b[39;00m ConfigCompositionException(msg)\n",
+      "\u001b[0;31mConfigCompositionException\u001b[0m: Could not override 'llc_group@lower_level_class'.\nDid you mean to override llc_group@mid_level_class.lower_level_class?\nTo append to your default list use +llc_group@lower_level_class=llc_2"
+     ]
+    }
+   ],
+   "source": [
+    "out = launch(\n",
+    "    tlc_1, \n",
+    "    launch_and_instantiate, \n",
+    "    overrides=['llc_group@lower_level_class=llc_2']\n",
+    "    )\n",
+    "out.return_value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### using context manager"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with ConfMode():\n",
+    "    LowerLevelClass(\n",
+    "        name_='lower_level_class_5',\n",
+    "        group_='lower_level_class',\n",
+    "        b=117,\n",
+    "    )\n",
+    "    top_level_class_config_2 = TopLevelClass(\n",
+    "        a=-9,\n",
+    "        name_='top_level_class_2', \n",
+    "        defaults=[\n",
+    "            '_self_', \n",
+    "            {'lower_level_class': 'lower_level_class_5'}]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(-9, LowerLevelClass(99))"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out = launch(\n",
+    "    top_level_class_config_2, \n",
+    "    launch_and_instantiate, \n",
+    "    overrides=['lower_level_class=lower_level_class_4']\n",
+    "    )\n",
+    "out.return_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/core/default_element.py:122: UserWarning: In 'lower_level_class/lower_level_class_5': Usage of deprecated keyword in package header '# @package _group_'.\n",
+      "See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
+      "  deprecation_warning(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(-9, LowerLevelClass(123))"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "out = launch(\n",
+    "    top_level_class_config_2, \n",
+    "    launch_and_instantiate, \n",
+    "    overrides=['lower_level_class.b=123']\n",
+    "    )\n",
+    "out.return_value"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# on something more concrete"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from thundercloud.torch.models.components.backbone import LazyBlock, StackedLazyBlocks\n",
+    "from thundercloud.torch.models.model import GenericModel\n",
+    "from typing import Optional, List, Dict, Union\n",
+    "from torch import nn\n",
+    "from functools import partial\n",
+    "from hydra_zen import instantiate\n",
+    "from collections import OrderedDict\n",
+    "from pprint import pprint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# setup conf for torch primitives\n",
+    "Linear = add_conf(nn.Linear)\n",
+    "LazyLinear = add_conf(nn.LazyLinear)\n",
+    "ReLU = add_conf(nn.ReLU)\n",
+    "Dropout = add_conf(nn.Dropout)\n",
+    "BatchNorm = add_conf(nn.BatchNorm1d)\n",
+    "Identity = add_conf(nn.Identity)\n",
+    "Module = add_conf(nn.Module)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# build sequential wrapper\n",
+    "import functools\n",
+    "\n",
+    "    \n",
+    "# @functools.wraps(nn.Sequential, updated=())\n",
+    "@add_func_conf(hydra_recursive=False, zen_partial=False)\n",
+    "def make_sequential(\n",
+    "    components:Union[List, Dict]=None,\n",
+    "    **kwargs,\n",
+    "):\n",
+    "    if isinstance(components, dict):\n",
+    "        components = list(components.values())\n",
+    "    return nn.Sequential(*[instantiate(c) for c in components])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 90,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "types.Builds_make_sequential"
+      ]
+     },
+     "execution_count": 90,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "make_sequential.conf"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# configure\n",
+    "with ConfMode():\n",
+    "    sequential = make_sequential(\n",
+    "        components=[\n",
+    "            Linear(in_features=1, out_features=2), \n",
+    "            Linear(in_features=2, out_features=1)\n",
+    "            ]\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_make_sequential(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.make_sequential', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, components=[Builds_Linear(_target_='hydra_zen.funcs.zen_processing', _zen_target='torch.nn.modules.linear.Linear', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), in_features=1, out_features=2, bias=True, device=None, dtype=None, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_']), Builds_Linear(_target_='hydra_zen.funcs.zen_processing', _zen_target='torch.nn.modules.linear.Linear', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), in_features=2, out_features=1, bias=True, device=None, dtype=None, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])], name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 92,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sequential"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 93,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Linear(in_features=1, out_features=2, bias=True)"
+      ]
+     },
+     "execution_count": 93,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "instantiate(sequential.components[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 94,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Sequential(\n",
+       "  (0): Linear(in_features=1, out_features=2, bias=True)\n",
+       "  (1): Linear(in_features=2, out_features=1, bias=True)\n",
+       ")"
+      ]
+     },
+     "execution_count": 94,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sequential.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Sequential(\n",
+       "  (0): Linear(in_features=3, out_features=2, bias=True)\n",
+       "  (1): Linear(in_features=2, out_features=1, bias=True)\n",
+       ")"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# do overrides\n",
+    "launch(sequential, launch_and_instantiate, overrides=['components.0.in_features=3']).return_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# class based sequential that is recursive\n",
+    "from thundercloud.torch.models.components.backbone import Sequential\n",
+    "\n",
+    "with ConfMode():\n",
+    "    my_sequence = Sequential(\n",
+    "        components=[\n",
+    "            Linear(in_features=1, out_features=2), \n",
+    "            Linear(in_features=2, out_features=1)\n",
+    "        ]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_Sequential(_target_='hydra_zen.funcs.zen_processing', _zen_target='thundercloud.torch.models.components.backbone.Sequential', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), components=[Builds_Linear(_target_='hydra_zen.funcs.zen_processing', _zen_target='torch.nn.modules.linear.Linear', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), in_features=1, out_features=2, bias=True, device=None, dtype=None, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_']), Builds_Linear(_target_='hydra_zen.funcs.zen_processing', _zen_target='torch.nn.modules.linear.Linear', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), in_features=2, out_features=1, bias=True, device=None, dtype=None, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])], name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_sequence"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Sequential(\n",
+       "  (0): Linear(in_features=1, out_features=2, bias=True)\n",
+       "  (1): Linear(in_features=2, out_features=1, bias=True)\n",
+       ")"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_sequence = my_sequence.instantiate()\n",
+    "my_sequence"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## rebuild lazy block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# rebuild lazy block\n",
+    "\n",
+    "with ConfMode():\n",
+    "\n",
+    "    dropout = Dropout(p=0., name_='dropout')\n",
+    "    \n",
+    "    linear = LazyLinear(\n",
+    "        out_features=1, \n",
+    "        group_='linear', \n",
+    "        name_='LazyLinear',\n",
+    "        )\n",
+    "    \n",
+    "    @add_func_conf(hydra_recursive=False, zen_partial=False)\n",
+    "    def make_lazy_block(\n",
+    "            out_features:int = 1,\n",
+    "            input_dropout: Optional[Any] = dropout,\n",
+    "            linear=linear,\n",
+    "            activation: Optional[Any] = MISSING,\n",
+    "            output_dropout: Optional[Any] = dropout,\n",
+    "            batch_norm: Optional[Any] = MISSING,\n",
+    "            **kwargs,\n",
+    "        ):\n",
+    "            net = nn.Sequential()\n",
+    "            if input_dropout is not None:\n",
+    "                net.append(instantiate(input_dropout))\n",
+    "            net.append(instantiate(linear, out_features=out_features))\n",
+    "            if activation is not None:\n",
+    "                net.append(instantiate(activation))\n",
+    "            if output_dropout is not None:\n",
+    "                net.append(instantiate(output_dropout))\n",
+    "            if batch_norm is not None:\n",
+    "                net.append(instantiate(batch_norm, num_features=out_features))\n",
+    "            return net\n",
+    "    \n",
+    "\n",
+    "    \n",
+    "    # create a bunch of config options\n",
+    "    \n",
+    "    batch_norm = BatchNorm(\n",
+    "        num_features=1, \n",
+    "        group_='batch_norm', \n",
+    "        name_='BatchNorm',\n",
+    "        )\n",
+    "    \n",
+    "    # activations \n",
+    "    identity = Identity(group_='activation', name_='Identity')\n",
+    "    relu = ReLU(group_='activation', name_='ReLU')\n",
+    "\n",
+    "    # set defaults list\n",
+    "    zen_lazy_block = make_lazy_block(\n",
+    "        defaults=[\n",
+    "            '_self_',\n",
+    "            'linear/LazyLinear',\n",
+    "            {'activation': 'Identity'},\n",
+    "            'batch_norm/BatchNorm',\n",
+    "        ]\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 179,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Builds_make_lazy_block(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.make_lazy_block', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, out_features=1, input_dropout=Builds_Dropout(_target_='hydra_zen.funcs.zen_processing', _zen_target='torch.nn.modules.dropout.Dropout', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), p=0.0, inplace=False, name_='dropout', group_=None, package_='_group_', provider_=None, defaults=['_self_']), linear=Builds_LazyLinear(_target_='hydra_zen.funcs.zen_processing', _zen_target='torch.nn.modules.linear.LazyLinear', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), out_features=1, bias=True, device=None, dtype=None, name_='LazyLinear', group_='linear', package_='_group_', provider_=None, defaults=['_self_']), activation='???', output_dropout=Builds_Dropout(_target_='hydra_zen.funcs.zen_processing', _zen_target='torch.nn.modules.dropout.Dropout', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), p=0.0, inplace=False, name_='dropout', group_=None, package_='_group_', provider_=None, defaults=['_self_']), batch_norm='???', name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_', 'linear/LazyLinear', {'activation': 'Identity'}, 'batch_norm/BatchNorm'])"
+      ]
+     },
+     "execution_count": 179,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zen_lazy_block"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 180,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Sequential(\n",
+       "  (0): Dropout(p=0.2, inplace=False)\n",
+       "  (1): LazyLinear(in_features=0, out_features=8, bias=True)\n",
+       "  (2): ReLU()\n",
+       "  (3): Dropout(p=0.0, inplace=False)\n",
+       "  (4): BatchNorm1d(8, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       ")"
+      ]
+     },
+     "execution_count": 180,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "launch(\n",
+    "    zen_lazy_block, \n",
+    "    launch_and_instantiate, \n",
+    "    overrides=[\n",
+    "        'out_features=8', \n",
+    "        'activation=ReLU', \n",
+    "        'input_dropout.p=0.2'\n",
+    "        ],\n",
+    "    ).return_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# we've also implemented a class based LazyBlock\n",
+    "# we can use it in combo with our Sequential wrapper to demonstrate using a base config that you can alter\n",
+    "\n",
+    "from thundercloud.torch.models.components.backbone import LazyBlock,LazyLinear,Dropout,ReLU,BatchNorm, Sequential\n",
+    "\n",
+    "with ConfMode():\n",
+    "\n",
+    "    # this is a partial conf, missing out_features\n",
+    "    lazy_block_base = LazyBlock(\n",
+    "        activation = ReLU(),\n",
+    "        output_dropout = Dropout(p=0., name_='dropout'),\n",
+    "        batch_norm = BatchNorm()\n",
+    "    )\n",
+    "\n",
+    "    # modify the base conf for each element in the list\n",
+    "    my_sequential = Sequential(\n",
+    "        components = [\n",
+    "            lazy_block_base(out_features = 256,input_dropout = Dropout(p=0.2, name_='dropout')),\n",
+    "            lazy_block_base(out_features = 128),\n",
+    "            lazy_block_base(out_features = 64)\n",
+    "        ]\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_zen_target: thundercloud.torch.models.components.backbone.Sequential\n",
+      "components:\n",
+      "- _zen_target: thundercloud.torch.models.components.backbone.LazyBlock\n",
+      "  out_features: 256\n",
+      "  input_dropout:\n",
+      "    _zen_target: torch.nn.modules.dropout.Dropout\n",
+      "    p: 0.2\n",
+      "    inplace: false\n",
+      "    name_: dropout\n",
+      "  activation:\n",
+      "    _zen_target: torch.nn.modules.activation.ReLU\n",
+      "    inplace: false\n",
+      "  output_dropout:\n",
+      "    _zen_target: torch.nn.modules.dropout.Dropout\n",
+      "    p: 0.0\n",
+      "    inplace: false\n",
+      "    name_: dropout\n",
+      "  batch_norm:\n",
+      "    _zen_target: torch.nn.modules.batchnorm.BatchNorm1d\n",
+      "    num_features: 1\n",
+      "    eps: 1.0e-05\n",
+      "    momentum: 0.1\n",
+      "    affine: true\n",
+      "    track_running_stats: true\n",
+      "    device: null\n",
+      "    dtype: null\n",
+      "- _zen_target: thundercloud.torch.models.components.backbone.LazyBlock\n",
+      "  out_features: 128\n",
+      "  input_dropout: null\n",
+      "  activation:\n",
+      "    _zen_target: torch.nn.modules.activation.ReLU\n",
+      "    inplace: false\n",
+      "  output_dropout:\n",
+      "    _zen_target: torch.nn.modules.dropout.Dropout\n",
+      "    p: 0.0\n",
+      "    inplace: false\n",
+      "    name_: dropout\n",
+      "  batch_norm:\n",
+      "    _zen_target: torch.nn.modules.batchnorm.BatchNorm1d\n",
+      "    num_features: 1\n",
+      "    eps: 1.0e-05\n",
+      "    momentum: 0.1\n",
+      "    affine: true\n",
+      "    track_running_stats: true\n",
+      "    device: null\n",
+      "    dtype: null\n",
+      "- _zen_target: thundercloud.torch.models.components.backbone.LazyBlock\n",
+      "  out_features: 64\n",
+      "  input_dropout: null\n",
+      "  activation:\n",
+      "    _zen_target: torch.nn.modules.activation.ReLU\n",
+      "    inplace: false\n",
+      "  output_dropout:\n",
+      "    _zen_target: torch.nn.modules.dropout.Dropout\n",
+      "    p: 0.0\n",
+      "    inplace: false\n",
+      "    name_: dropout\n",
+      "  batch_norm:\n",
+      "    _zen_target: torch.nn.modules.batchnorm.BatchNorm1d\n",
+      "    num_features: 1\n",
+      "    eps: 1.0e-05\n",
+      "    momentum: 0.1\n",
+      "    affine: true\n",
+      "    track_running_stats: true\n",
+      "    device: null\n",
+      "    dtype: null\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "my_sequential.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/torch/nn/modules/lazy.py:178: UserWarning: Lazy modules are a new feature under heavy development so changes to the API or functionality can happen at any moment.\n",
+      "  warnings.warn('Lazy modules are a new feature under heavy development '\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Sequential(\n",
+       "  (0): LazyBlock(\n",
+       "    (0): Dropout(p=0.2, inplace=False)\n",
+       "    (1): LazyLinear(in_features=0, out_features=256, bias=True)\n",
+       "    (2): ReLU()\n",
+       "    (3): Dropout(p=0.0, inplace=False)\n",
+       "    (4): BatchNorm1d(256, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "  )\n",
+       "  (1): LazyBlock(\n",
+       "    (0): LazyLinear(in_features=0, out_features=128, bias=True)\n",
+       "    (1): ReLU()\n",
+       "    (2): Dropout(p=0.0, inplace=False)\n",
+       "    (3): BatchNorm1d(128, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "  )\n",
+       "  (2): LazyBlock(\n",
+       "    (0): LazyLinear(in_features=0, out_features=64, bias=True)\n",
+       "    (1): ReLU()\n",
+       "    (2): Dropout(p=0.0, inplace=False)\n",
+       "    (3): BatchNorm1d(64, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "  )\n",
+       ")"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_sequential = my_sequential.instantiate()\n",
+    "my_sequential"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 182,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# back to working with the function versions\n",
+    "\n",
+    "with ConfMode():\n",
+    "    relu_zen_block = make_lazy_block(\n",
+    "        activation=relu,\n",
+    "        batch_norm=batch_norm,\n",
+    "        )\n",
+    "    sequential = make_sequential(\n",
+    "        components=[\n",
+    "            relu_zen_block,\n",
+    "            relu_zen_block,\n",
+    "            relu_zen_block,\n",
+    "            ]\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 184,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "instantiated_sequential = launch(\n",
+    "    sequential, \n",
+    "    launch_and_instantiate, \n",
+    "    # overrides=['components.0.out_features=6',],\n",
+    "    ).return_value"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 185,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Sequential(\n",
+       "  (0): Sequential(\n",
+       "    (0): Dropout(p=0.0, inplace=False)\n",
+       "    (1): LazyLinear(in_features=0, out_features=1, bias=True)\n",
+       "    (2): ReLU()\n",
+       "    (3): Dropout(p=0.0, inplace=False)\n",
+       "    (4): BatchNorm1d(1, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "  )\n",
+       "  (1): Sequential(\n",
+       "    (0): Dropout(p=0.0, inplace=False)\n",
+       "    (1): LazyLinear(in_features=0, out_features=1, bias=True)\n",
+       "    (2): ReLU()\n",
+       "    (3): Dropout(p=0.0, inplace=False)\n",
+       "    (4): BatchNorm1d(1, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "  )\n",
+       "  (2): Sequential(\n",
+       "    (0): Dropout(p=0.0, inplace=False)\n",
+       "    (1): LazyLinear(in_features=0, out_features=1, bias=True)\n",
+       "    (2): ReLU()\n",
+       "    (3): Dropout(p=0.0, inplace=False)\n",
+       "    (4): BatchNorm1d(1, eps=1e-05, momentum=0.1, affine=True, track_running_stats=True)\n",
+       "  )\n",
+       ")"
+      ]
+     },
+     "execution_count": 185,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "instantiated_sequential"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class TimesX:\n",
+    "    def __init__(self,x=1.0):\n",
+    "        self.x = x\n",
+    "    \n",
+    "    def times(self,y=1.0):\n",
+    "        return self.x*y\n",
+    "\n",
+    "class Times2X(TimesX):\n",
+    "    def __init__(self,x=1.0):\n",
+    "        super().__init__(2*x)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "0da9c4590e589478921e261661d76c6c7ab7b3f3af4a42bc07d53b3af401017b"
+  },
+  "kernelspec": {
+   "display_name": "Python 3.9.10 ('orange')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.10"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ipynb/add_conf_demo.ipynb
+++ b/ipynb/add_conf_demo.ipynb
@@ -8,10 +8,9 @@
    "source": [
     "#from hydra_zen import add_batteries, add_func_conf, ConfMode, _add_batteries, cs, zen_dry_run, launch_and_instantiate\n",
     "from hydra_zen.structured_configs._add_conf import ConfMode, add_batteries, add_batteries, BatteriesIncludedConf, cs\n",
-    "from hydra_zen import launch, instantiate\n",
+    "from hydra_zen import launch, instantiate, store\n",
     "from typing import Any, List\n",
     "from omegaconf import MISSING\n",
-    "import pandas as pd\n",
     "%load_ext autoreload \n",
     "%autoreload 2\n",
     "%config Completer.use_jedi = False"
@@ -54,7 +53,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
@@ -63,7 +62,7 @@
        "MyClass(dog, 3)"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -87,7 +86,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -96,7 +95,7 @@
        "types.Builds_MyClass"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -108,7 +107,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -117,7 +116,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='dog', b=3, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 22,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -130,7 +129,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -139,7 +138,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -151,7 +150,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -160,7 +159,7 @@
        "MyClass(dog, 3)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -172,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -181,7 +180,7 @@
        "MyClass(Bloom, 3)"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -193,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -202,7 +201,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -221,7 +220,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -230,7 +229,7 @@
        "MyClass(Lily, 3)"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -242,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -251,7 +250,7 @@
        "MyClass(Lily, 3)"
       ]
      },
-     "execution_count": 91,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -263,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -272,7 +271,7 @@
        "MyClass(Bloom, 47)"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -286,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -295,7 +294,7 @@
        "MyClass(Bloom, 117)"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -309,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -318,7 +317,7 @@
        "MyClass(Lily, 117)"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -329,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -338,7 +337,7 @@
        "True"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -349,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -358,7 +357,7 @@
        "True"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -376,7 +375,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +385,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {
@@ -416,16 +415,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "data": {
+      "text/html": [
+       "<style>#sk-container-id-1 {color: black;background-color: white;}#sk-container-id-1 pre{padding: 0;}#sk-container-id-1 div.sk-toggleable {background-color: white;}#sk-container-id-1 label.sk-toggleable__label {cursor: pointer;display: block;width: 100%;margin-bottom: 0;padding: 0.3em;box-sizing: border-box;text-align: center;}#sk-container-id-1 label.sk-toggleable__label-arrow:before {content: \"▸\";float: left;margin-right: 0.25em;color: #696969;}#sk-container-id-1 label.sk-toggleable__label-arrow:hover:before {color: black;}#sk-container-id-1 div.sk-estimator:hover label.sk-toggleable__label-arrow:before {color: black;}#sk-container-id-1 div.sk-toggleable__content {max-height: 0;max-width: 0;overflow: hidden;text-align: left;background-color: #f0f8ff;}#sk-container-id-1 div.sk-toggleable__content pre {margin: 0.2em;color: black;border-radius: 0.25em;background-color: #f0f8ff;}#sk-container-id-1 input.sk-toggleable__control:checked~div.sk-toggleable__content {max-height: 200px;max-width: 100%;overflow: auto;}#sk-container-id-1 input.sk-toggleable__control:checked~label.sk-toggleable__label-arrow:before {content: \"▾\";}#sk-container-id-1 div.sk-estimator input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-label input.sk-toggleable__control:checked~label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 input.sk-hidden--visually {border: 0;clip: rect(1px 1px 1px 1px);clip: rect(1px, 1px, 1px, 1px);height: 1px;margin: -1px;overflow: hidden;padding: 0;position: absolute;width: 1px;}#sk-container-id-1 div.sk-estimator {font-family: monospace;background-color: #f0f8ff;border: 1px dotted black;border-radius: 0.25em;box-sizing: border-box;margin-bottom: 0.5em;}#sk-container-id-1 div.sk-estimator:hover {background-color: #d4ebff;}#sk-container-id-1 div.sk-parallel-item::after {content: \"\";width: 100%;border-bottom: 1px solid gray;flex-grow: 1;}#sk-container-id-1 div.sk-label:hover label.sk-toggleable__label {background-color: #d4ebff;}#sk-container-id-1 div.sk-serial::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: 0;}#sk-container-id-1 div.sk-serial {display: flex;flex-direction: column;align-items: center;background-color: white;padding-right: 0.2em;padding-left: 0.2em;position: relative;}#sk-container-id-1 div.sk-item {position: relative;z-index: 1;}#sk-container-id-1 div.sk-parallel {display: flex;align-items: stretch;justify-content: center;background-color: white;position: relative;}#sk-container-id-1 div.sk-item::before, #sk-container-id-1 div.sk-parallel-item::before {content: \"\";position: absolute;border-left: 1px solid gray;box-sizing: border-box;top: 0;bottom: 0;left: 50%;z-index: -1;}#sk-container-id-1 div.sk-parallel-item {display: flex;flex-direction: column;z-index: 1;position: relative;background-color: white;}#sk-container-id-1 div.sk-parallel-item:first-child::after {align-self: flex-end;width: 50%;}#sk-container-id-1 div.sk-parallel-item:last-child::after {align-self: flex-start;width: 50%;}#sk-container-id-1 div.sk-parallel-item:only-child::after {width: 0;}#sk-container-id-1 div.sk-dashed-wrapped {border: 1px dashed gray;margin: 0 0.4em 0.5em 0.4em;box-sizing: border-box;padding-bottom: 0.4em;background-color: white;}#sk-container-id-1 div.sk-label label {font-family: monospace;font-weight: bold;display: inline-block;line-height: 1.2em;}#sk-container-id-1 div.sk-label-container {text-align: center;}#sk-container-id-1 div.sk-container {/* jupyter's `normalize.less` sets `[hidden] { display: none; }` but bootstrap.min.css set `[hidden] { display: none !important; }` so we also need the `!important` here to be able to override the default hidden behavior on the sphinx rendered scikit-learn.org. See: https://github.com/scikit-learn/scikit-learn/issues/21755 */display: inline-block !important;position: relative;}#sk-container-id-1 div.sk-text-repr-fallback {display: none;}</style><div id=\"sk-container-id-1\" class=\"sk-top-container\"><div class=\"sk-text-repr-fallback\"><pre>LogisticRegression(penalty=&#x27;l1&#x27;)</pre><b>In a Jupyter environment, please rerun this cell to show the HTML representation or trust the notebook. <br />On GitHub, the HTML representation is unable to render, please try loading this page with nbviewer.org.</b></div><div class=\"sk-container\" hidden><div class=\"sk-item\"><div class=\"sk-estimator sk-toggleable\"><input class=\"sk-toggleable__control sk-hidden--visually\" id=\"sk-estimator-id-1\" type=\"checkbox\" checked><label for=\"sk-estimator-id-1\" class=\"sk-toggleable__label sk-toggleable__label-arrow\">LogisticRegression</label><div class=\"sk-toggleable__content\"><pre>LogisticRegression(penalty=&#x27;l1&#x27;)</pre></div></div></div></div></div>"
+      ],
       "text/plain": [
        "LogisticRegression(penalty='l1')"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -437,16 +439,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alexnaka/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/torch/nn/modules/lazy.py:178: UserWarning: Lazy modules are a new feature under heavy development so changes to the API or functionality can happen at any moment.\n",
+      "  warnings.warn('Lazy modules are a new feature under heavy development '\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "LazyLinear(in_features=0, out_features=2, bias=True)"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -460,7 +470,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [
     {
@@ -469,7 +479,7 @@
        "Builds_LogisticRegression(_target_='hydra_zen.funcs.zen_processing', _zen_target='sklearn.linear_model._logistic.LogisticRegression', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), penalty='l2', dual=False, tol=0.0001, C=1.0, fit_intercept=True, intercept_scaling=1, class_weight=None, random_state=None, solver='lbfgs', max_iter=100, multi_class='auto', verbose=0, warm_start=False, n_jobs=None, l1_ratio=None, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -482,7 +492,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,9 +509,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'add_func_conf' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[23], line 4\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39m# works the same as above - gives function a .conf attribute\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[39m# does not work with positional arguments - you need some kind of default value, even if it is None or MISSING\u001b[39;00m\n\u001b[1;32m      3\u001b[0m \u001b[39m# by default this returns a partial\u001b[39;00m\n\u001b[0;32m----> 4\u001b[0m \u001b[39m@add_func_conf\u001b[39m\n\u001b[1;32m      5\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39madd_numbers\u001b[39m(a:\u001b[39mint\u001b[39m\u001b[39m=\u001b[39mMISSING, b:\u001b[39mint\u001b[39m\u001b[39m=\u001b[39mMISSING):\n\u001b[1;32m      6\u001b[0m     \u001b[39mreturn\u001b[39;00m a \u001b[39m+\u001b[39m b\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'add_func_conf' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# works the same as above - gives function a .conf attribute\n",
     "# does not work with positional arguments - you need some kind of default value, even if it is None or MISSING\n",
@@ -513,18 +535,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "3"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'add_numbers' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[24], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m add_numbers\u001b[39m.\u001b[39mConf(a\u001b[39m=\u001b[39m\u001b[39m1\u001b[39m, b\u001b[39m=\u001b[39m\u001b[39m2\u001b[39m)\u001b[39m.\u001b[39minstantiate()()\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'add_numbers' is not defined"
+     ]
     }
    ],
    "source": [
@@ -533,9 +556,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 25,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'add_func_conf' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[25], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39m# add_func_conf lets you change settings being used in hydra_zen.builds under the hood\u001b[39;00m\n\u001b[1;32m      2\u001b[0m \u001b[39m# here we make it so that the function is not wrapped in a partial\u001b[39;00m\n\u001b[0;32m----> 3\u001b[0m \u001b[39m@add_func_conf\u001b[39m(zen_partial\u001b[39m=\u001b[39m\u001b[39mFalse\u001b[39;00m)\n\u001b[1;32m      4\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mmake_dataframe\u001b[39m():\n\u001b[1;32m      5\u001b[0m     \u001b[39mreturn\u001b[39;00m pd\u001b[39m.\u001b[39mDataFrame({\u001b[39m'\u001b[39m\u001b[39ma\u001b[39m\u001b[39m'\u001b[39m: \u001b[39m1\u001b[39m}, index\u001b[39m=\u001b[39m[\u001b[39m0\u001b[39m])\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'add_func_conf' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# add_func_conf lets you change settings being used in hydra_zen.builds under the hood\n",
     "# here we make it so that the function is not wrapped in a partial\n",
@@ -546,50 +581,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>a</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "   a\n",
-       "0  1"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "NameError",
+     "evalue": "name 'make_dataframe' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[26], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39m# now instantiation just immediately returns the dataframe\u001b[39;00m\n\u001b[0;32m----> 2\u001b[0m make_dataframe\u001b[39m.\u001b[39mConf()\u001b[39m.\u001b[39minstantiate()\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'make_dataframe' is not defined"
+     ]
     }
    ],
    "source": [
@@ -656,43 +660,82 @@
    "source": [
     "# decorated classes will accept name_, group_, and defaults as arguments\n",
     "lower_level_class = LowerLevelClass(\n",
-    "    name_='lower_level_class_1',\n",
+    "    name_='lower_level_class_2',\n",
     "    )\n",
     "lower_level_class"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b='hello', name_='lower_level_class_1', group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lower_level_class.conf.store()"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['_dummy_empty_config_.yaml', 'hydra']"
+       "'lower_level_class_2'"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lower_level_class.conf.name_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "store(lower_level_class.conf, name=lower_level_class.conf.name_, group=lower_level_class.conf.group_)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "zen_store\n",
+       "{None: ['lower_level_class_1', 'lower_level_class_2']}"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "store"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['_dummy_empty_config_.yaml', 'hydra', 'lower_level_class_2.yaml']"
+      ]
+     },
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -704,20 +747,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b=99, name_='lower_level_class_2', group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# constructing the .conf dataclass with a name_ argument will also automatically store it in ConfigStore\n",
     "LowerLevelClass.Conf(\n",
@@ -728,16 +760,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['_dummy_empty_config_.yaml', 'hydra']"
+       "['_dummy_empty_config_.yaml',\n",
+       " 'hydra',\n",
+       " 'lower_level_class_1.yaml',\n",
+       " 'lower_level_class_2.yaml']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -748,7 +783,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -757,7 +792,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b=99, name_='lower_level_class_4', group_='lower_level_class', package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -778,18 +813,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b='hello', name_='lower_level_class_3', group_='lower_level_class', package_='_group_', provider_=None, defaults=['_self_'])"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
+     "ename": "ValueError",
+     "evalue": "(name=lower_level_class_3 group=lower_level_class): Store entry already exists. Use a store initialized with `ZenStore(overwrite_ok=True)` to overwrite config store entries.",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[10], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m LowerLevelClass(\n\u001b[1;32m      2\u001b[0m     name_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class_3\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      3\u001b[0m     group_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      4\u001b[0m     )\u001b[39m.\u001b[39mconf\n",
+      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:548\u001b[0m, in \u001b[0;36m_batteries_included_override_constructor.<locals>.WrappedClass.__init__\u001b[0;34m(self, name_, group_, package_, provider_, defaults, *args, **kwargs)\u001b[0m\n\u001b[1;32m    544\u001b[0m zen_meta \u001b[39m=\u001b[39m merge_zen_meta_defaults(\n\u001b[1;32m    545\u001b[0m     name_, group_, package_, provider_, defaults\n\u001b[1;32m    546\u001b[0m )\n\u001b[1;32m    547\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mhasattr\u001b[39m(\u001b[39mself\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39mconf\u001b[39m\u001b[39m\"\u001b[39m):\n\u001b[0;32m--> 548\u001b[0m     conf \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mConf(\u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mzen_meta, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    549\u001b[0m     \u001b[39msetattr\u001b[39m(\u001b[39mself\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39mconf\u001b[39m\u001b[39m\"\u001b[39m, conf)\n\u001b[1;32m    550\u001b[0m \u001b[39msuper\u001b[39m()\u001b[39m.\u001b[39m\u001b[39m__init__\u001b[39m(\u001b[39m*\u001b[39margs, \u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkwargs)\n",
+      "File \u001b[0;32m<string>:9\u001b[0m, in \u001b[0;36m__init__\u001b[0;34m(self, b, name_, group_, package_, provider_, defaults)\u001b[0m\n",
+      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:318\u001b[0m, in \u001b[0;36mBatteriesIncludedConf.__post_init__\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    316\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__post_init__\u001b[39m(\u001b[39mself\u001b[39m):\n\u001b[1;32m    317\u001b[0m     \u001b[39mif\u001b[39;00m \u001b[39mgetattr\u001b[39m(\u001b[39mself\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39mname_\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39mNone\u001b[39;00m) \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 318\u001b[0m         \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mstore()\n",
+      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:386\u001b[0m, in \u001b[0;36mBatteriesIncludedConf.store\u001b[0;34m(self, add_to_hydra_store)\u001b[0m\n\u001b[1;32m    380\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mstore\u001b[39m(\u001b[39mself\u001b[39m, add_to_hydra_store:\u001b[39mbool\u001b[39m\u001b[39m=\u001b[39m\u001b[39mTrue\u001b[39;00m):\n\u001b[1;32m    381\u001b[0m     \u001b[39m\"\"\"Stores object in the config store.\u001b[39;00m\n\u001b[1;32m    382\u001b[0m \n\u001b[1;32m    383\u001b[0m \u001b[39m    Returns:\u001b[39;00m\n\u001b[1;32m    384\u001b[0m \u001b[39m        The object itself (for chaining)\u001b[39;00m\n\u001b[1;32m    385\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 386\u001b[0m     store(\n\u001b[1;32m    387\u001b[0m         \u001b[39mself\u001b[39;49m,\n\u001b[1;32m    388\u001b[0m         name\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mname_,\n\u001b[1;32m    389\u001b[0m         group\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mgroup_,\n\u001b[1;32m    390\u001b[0m     )\n\u001b[1;32m    391\u001b[0m     \u001b[39mif\u001b[39;00m add_to_hydra_store:\n\u001b[1;32m    392\u001b[0m         store\u001b[39m.\u001b[39madd_to_hydra_store()\n",
+      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/wrapper/_implementations.py:1285\u001b[0m, in \u001b[0;36mZenStore.__call__\u001b[0;34m(self, _ZenStore__target, **kw)\u001b[0m\n\u001b[1;32m   1276\u001b[0m entry \u001b[39m=\u001b[39m StoreEntry(\n\u001b[1;32m   1277\u001b[0m     name\u001b[39m=\u001b[39m_name,\n\u001b[1;32m   1278\u001b[0m     group\u001b[39m=\u001b[39m_group,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m   1281\u001b[0m     node\u001b[39m=\u001b[39mnode,\n\u001b[1;32m   1282\u001b[0m )\n\u001b[1;32m   1284\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_overwrite_ok \u001b[39mand\u001b[39;00m (_group, _name) \u001b[39min\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_internal_repo:\n\u001b[0;32m-> 1285\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\n\u001b[1;32m   1286\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m(name=\u001b[39m\u001b[39m{\u001b[39;00mentry[\u001b[39m'\u001b[39m\u001b[39mname\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m}\u001b[39;00m\u001b[39m group=\u001b[39m\u001b[39m{\u001b[39;00mentry[\u001b[39m'\u001b[39m\u001b[39mgroup\u001b[39m\u001b[39m'\u001b[39m]\u001b[39m}\u001b[39;00m\u001b[39m): \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m   1287\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mStore entry already exists. Use a store initialized \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m   1288\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mwith `ZenStore(overwrite_ok=True)` to overwrite config store \u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m   1289\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mentries.\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m   1290\u001b[0m     )\n\u001b[1;32m   1291\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_internal_repo[_group, _name] \u001b[39m=\u001b[39m entry\n\u001b[1;32m   1292\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_queue\u001b[39m.\u001b[39mappend(entry)\n",
+      "\u001b[0;31mValueError\u001b[0m: (name=lower_level_class_3 group=lower_level_class): Store entry already exists. Use a store initialized with `ZenStore(overwrite_ok=True)` to overwrite config store entries."
+     ]
     }
    ],
    "source": [
@@ -801,7 +842,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -814,43 +855,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/naka/code/hydra-zen/src/hydra_zen/_launch.py:236: UserWarning: \n",
+      "/Users/alexnaka/code/hydra-zen/src/hydra_zen/_launch.py:236: UserWarning: \n",
       "The version_base parameter is not specified.\n",
       "Please specify a compatability version level, or None.\n",
       "Will assume defaults for version 1.1\n",
-      "  with initialize(\n"
+      "  with initialize(\n",
+      "/Users/alexnaka/code/hydra-zen/src/hydra_zen/_launch.py:270: UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.\n",
+      "See https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information.\n",
+      "  job = run_job(\n"
      ]
     },
     {
-     "ename": "MissingConfigException",
-     "evalue": "In 'zen_launch': Could not find 'lower_level_class/lower_level_class_3'\n\nConfig search path:\n\tprovider=hydra, path=pkg://hydra.conf\n\tprovider=schema, path=structured://",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mMissingConfigException\u001b[0m                    Traceback (most recent call last)",
-      "\u001b[1;32m/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb Cell 41\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X54sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m out \u001b[39m=\u001b[39m launch(top_level_class_config, launch_and_instantiate)\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X54sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
-      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/_launch.py:251\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    250\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> 251\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    252\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    253\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    254\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    255\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    256\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    257\u001b[0m )\n\u001b[1;32m    259\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    260\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    261\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    262\u001b[0m )\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    576\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    577\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    578\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    583\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    584\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    585\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    586\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    587\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    591\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    592\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 594\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    595\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    596\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    597\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    598\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    599\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    600\u001b[0m     )\n\u001b[1;32m    601\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    602\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:142\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    133\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    134\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    135\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    139\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    140\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    141\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 142\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    143\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    144\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    145\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    146\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    147\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    148\u001b[0m         )\n\u001b[1;32m    149\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    150\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:253\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39mif\u001b[39;00m validate_sweep_overrides:\n\u001b[1;32m    249\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mvalidate_sweep_overrides_legal(\n\u001b[1;32m    250\u001b[0m         overrides\u001b[39m=\u001b[39mparsed_overrides, run_mode\u001b[39m=\u001b[39mrun_mode, from_shell\u001b[39m=\u001b[39mfrom_shell\n\u001b[1;32m    251\u001b[0m     )\n\u001b[0;32m--> 253\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    254\u001b[0m     repo\u001b[39m=\u001b[39;49mcaching_repo,\n\u001b[1;32m    255\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    256\u001b[0m     overrides_list\u001b[39m=\u001b[39;49mparsed_overrides,\n\u001b[1;32m    257\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    258\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mrun_mode \u001b[39m==\u001b[39;49m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    259\u001b[0m )\n\u001b[1;32m    261\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[1;32m    263\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_compose_config_from_defaults_list(\n\u001b[1;32m    264\u001b[0m     defaults\u001b[39m=\u001b[39mdefaults_list\u001b[39m.\u001b[39mdefaults, repo\u001b[39m=\u001b[39mcaching_repo\n\u001b[1;32m    265\u001b[0m )\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:746\u001b[0m, in \u001b[0;36mcreate_defaults_list\u001b[0;34m(repo, config_name, overrides_list, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    737\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    738\u001b[0m \u001b[39m:param repo:\u001b[39;00m\n\u001b[1;32m    739\u001b[0m \u001b[39m:param config_name:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    743\u001b[0m \u001b[39m:return:\u001b[39;00m\n\u001b[1;32m    744\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    745\u001b[0m overrides \u001b[39m=\u001b[39m Overrides(repo\u001b[39m=\u001b[39mrepo, overrides_list\u001b[39m=\u001b[39moverrides_list)\n\u001b[0;32m--> 746\u001b[0m defaults, tree \u001b[39m=\u001b[39m _create_defaults_list(\n\u001b[1;32m    747\u001b[0m     repo,\n\u001b[1;32m    748\u001b[0m     config_name,\n\u001b[1;32m    749\u001b[0m     overrides,\n\u001b[1;32m    750\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49mprepend_hydra,\n\u001b[1;32m    751\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    752\u001b[0m )\n\u001b[1;32m    753\u001b[0m overrides\u001b[39m.\u001b[39mensure_overrides_used()\n\u001b[1;32m    754\u001b[0m overrides\u001b[39m.\u001b[39mensure_deletions_used()\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:716\u001b[0m, in \u001b[0;36m_create_defaults_list\u001b[0;34m(repo, config_name, overrides, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    706\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_create_defaults_list\u001b[39m(\n\u001b[1;32m    707\u001b[0m     repo: IConfigRepository,\n\u001b[1;32m    708\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    711\u001b[0m     skip_missing: \u001b[39mbool\u001b[39m,\n\u001b[1;32m    712\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m Tuple[List[ResultDefault], DefaultsTreeNode]:\n\u001b[1;32m    714\u001b[0m     root \u001b[39m=\u001b[39m _create_root(config_name\u001b[39m=\u001b[39mconfig_name, with_hydra\u001b[39m=\u001b[39mprepend_hydra)\n\u001b[0;32m--> 716\u001b[0m     defaults_tree \u001b[39m=\u001b[39m _create_defaults_tree(\n\u001b[1;32m    717\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    718\u001b[0m         root\u001b[39m=\u001b[39;49mroot,\n\u001b[1;32m    719\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    720\u001b[0m         is_root_config\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    721\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    722\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    723\u001b[0m     )\n\u001b[1;32m    725\u001b[0m     output \u001b[39m=\u001b[39m _tree_to_list(tree\u001b[39m=\u001b[39mdefaults_tree)\n\u001b[1;32m    726\u001b[0m     ensure_no_duplicates_in_list(output)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:356\u001b[0m, in \u001b[0;36m_create_defaults_tree\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    348\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_create_defaults_tree\u001b[39m(\n\u001b[1;32m    349\u001b[0m     repo: IConfigRepository,\n\u001b[1;32m    350\u001b[0m     root: DefaultsTreeNode,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    354\u001b[0m     overrides: Overrides,\n\u001b[1;32m    355\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DefaultsTreeNode:\n\u001b[0;32m--> 356\u001b[0m     ret \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    357\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    358\u001b[0m         root\u001b[39m=\u001b[39;49mroot,\n\u001b[1;32m    359\u001b[0m         is_root_config\u001b[39m=\u001b[39;49mis_root_config,\n\u001b[1;32m    360\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    361\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49minterpolated_subtree,\n\u001b[1;32m    362\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    363\u001b[0m     )\n\u001b[1;32m    365\u001b[0m     \u001b[39mreturn\u001b[39;00m ret\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:457\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    455\u001b[0m \u001b[39mif\u001b[39;00m parent\u001b[39m.\u001b[39mis_virtual():\n\u001b[1;32m    456\u001b[0m     \u001b[39mif\u001b[39;00m is_root_config:\n\u001b[0;32m--> 457\u001b[0m         \u001b[39mreturn\u001b[39;00m _expand_virtual_root(repo, root, overrides, skip_missing)\n\u001b[1;32m    458\u001b[0m     \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    459\u001b[0m         \u001b[39mreturn\u001b[39;00m root\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:280\u001b[0m, in \u001b[0;36m_expand_virtual_root\u001b[0;34m(repo, root, overrides, skip_missing)\u001b[0m\n\u001b[1;32m    277\u001b[0m new_root \u001b[39m=\u001b[39m DefaultsTreeNode(node\u001b[39m=\u001b[39md, parent\u001b[39m=\u001b[39mroot)\n\u001b[1;32m    278\u001b[0m d\u001b[39m.\u001b[39mupdate_parent(\u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m--> 280\u001b[0m subtree \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    281\u001b[0m     repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    282\u001b[0m     root\u001b[39m=\u001b[39;49mnew_root,\n\u001b[1;32m    283\u001b[0m     is_root_config\u001b[39m=\u001b[39;49md\u001b[39m.\u001b[39;49mprimary,\n\u001b[1;32m    284\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    285\u001b[0m     interpolated_subtree\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    286\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    287\u001b[0m )\n\u001b[1;32m    288\u001b[0m \u001b[39mif\u001b[39;00m subtree\u001b[39m.\u001b[39mchildren \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    289\u001b[0m     children\u001b[39m.\u001b[39mappend(d)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:573\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    570\u001b[0m                 \u001b[39mcontinue\u001b[39;00m\n\u001b[1;32m    572\u001b[0m             new_root \u001b[39m=\u001b[39m DefaultsTreeNode(node\u001b[39m=\u001b[39md, parent\u001b[39m=\u001b[39mroot)\n\u001b[0;32m--> 573\u001b[0m             add_child(children, new_root)\n\u001b[1;32m    575\u001b[0m \u001b[39m# processed deferred interpolations\u001b[39;00m\n\u001b[1;32m    576\u001b[0m known_choices \u001b[39m=\u001b[39m _create_interpolation_map(overrides, defaults_list, self_added)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:520\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl.<locals>.add_child\u001b[0;34m(child_list, new_root_)\u001b[0m\n\u001b[1;32m    516\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39madd_child\u001b[39m(\n\u001b[1;32m    517\u001b[0m     child_list: List[Union[InputDefault, DefaultsTreeNode]],\n\u001b[1;32m    518\u001b[0m     new_root_: DefaultsTreeNode,\n\u001b[1;32m    519\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 520\u001b[0m     subtree_ \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    521\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    522\u001b[0m         root\u001b[39m=\u001b[39;49mnew_root_,\n\u001b[1;32m    523\u001b[0m         is_root_config\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    524\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49minterpolated_subtree,\n\u001b[1;32m    525\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    526\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    527\u001b[0m     )\n\u001b[1;32m    528\u001b[0m     \u001b[39mif\u001b[39;00m subtree_\u001b[39m.\u001b[39mchildren \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    529\u001b[0m         child_list\u001b[39m.\u001b[39mappend(new_root_\u001b[39m.\u001b[39mnode)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:488\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    486\u001b[0m         parent\u001b[39m.\u001b[39mdeleted \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n\u001b[1;32m    487\u001b[0m         \u001b[39mreturn\u001b[39;00m root\n\u001b[0;32m--> 488\u001b[0m     config_not_found_error(repo\u001b[39m=\u001b[39;49mrepo, tree\u001b[39m=\u001b[39;49mroot)\n\u001b[1;32m    490\u001b[0m \u001b[39massert\u001b[39;00m loaded \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    491\u001b[0m defaults_list \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(loaded\u001b[39m.\u001b[39mdefaults_list)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:800\u001b[0m, in \u001b[0;36mconfig_not_found_error\u001b[0;34m(repo, tree)\u001b[0m\n\u001b[1;32m    797\u001b[0m lines \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39mjoin(descs)\n\u001b[1;32m    798\u001b[0m msg \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39mConfig search path:\u001b[39m\u001b[39m\"\u001b[39m \u001b[39m+\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00mlines\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 800\u001b[0m \u001b[39mraise\u001b[39;00m MissingConfigException(\n\u001b[1;32m    801\u001b[0m     missing_cfg_file\u001b[39m=\u001b[39melement\u001b[39m.\u001b[39mget_config_path(),\n\u001b[1;32m    802\u001b[0m     message\u001b[39m=\u001b[39mmsg,\n\u001b[1;32m    803\u001b[0m     options\u001b[39m=\u001b[39moptions,\n\u001b[1;32m    804\u001b[0m )\n",
-      "\u001b[0;31mMissingConfigException\u001b[0m: In 'zen_launch': Could not find 'lower_level_class/lower_level_class_3'\n\nConfig search path:\n\tprovider=hydra, path=pkg://hydra.conf\n\tprovider=schema, path=structured://"
-     ]
+     "data": {
+      "text/plain": [
+       "TopLevelClass(0, LowerLevelClass(hello))"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -860,14 +890,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/naka/code/hydra-zen/src/hydra_zen/_launch.py:236: UserWarning: \n",
+      "/Users/alexnaka/code/hydra-zen/src/hydra_zen/_launch.py:236: UserWarning: \n",
       "The version_base parameter is not specified.\n",
       "Please specify a compatability version level, or None.\n",
       "Will assume defaults for version 1.1\n",
@@ -875,28 +905,14 @@
      ]
     },
     {
-     "ename": "MissingConfigException",
-     "evalue": "In 'zen_launch': Could not find 'lower_level_class/lower_level_class_3'\n\nConfig search path:\n\tprovider=hydra, path=pkg://hydra.conf\n\tprovider=schema, path=structured://",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mMissingConfigException\u001b[0m                    Traceback (most recent call last)",
-      "\u001b[1;32m/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb Cell 41\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m out \u001b[39m=\u001b[39m launch(\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m     top_level_class_config, \n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m     launch_and_instantiate, \n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m     overrides\u001b[39m=\u001b[39;49m[\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class=lower_level_class_4\u001b[39;49m\u001b[39m'\u001b[39;49m])\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#X55sZmlsZQ%3D%3D?line=4'>5</a>\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
-      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/_launch.py:251\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    250\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> 251\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    252\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    253\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    254\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    255\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    256\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    257\u001b[0m )\n\u001b[1;32m    259\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    260\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    261\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    262\u001b[0m )\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    576\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    577\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    578\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    583\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    584\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    585\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    586\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    587\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    591\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    592\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 594\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    595\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    596\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    597\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    598\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    599\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    600\u001b[0m     )\n\u001b[1;32m    601\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    602\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:142\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    133\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    134\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    135\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    139\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    140\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    141\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 142\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    143\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    144\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    145\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    146\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    147\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    148\u001b[0m         )\n\u001b[1;32m    149\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    150\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/config_loader_impl.py:253\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39mif\u001b[39;00m validate_sweep_overrides:\n\u001b[1;32m    249\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mvalidate_sweep_overrides_legal(\n\u001b[1;32m    250\u001b[0m         overrides\u001b[39m=\u001b[39mparsed_overrides, run_mode\u001b[39m=\u001b[39mrun_mode, from_shell\u001b[39m=\u001b[39mfrom_shell\n\u001b[1;32m    251\u001b[0m     )\n\u001b[0;32m--> 253\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    254\u001b[0m     repo\u001b[39m=\u001b[39;49mcaching_repo,\n\u001b[1;32m    255\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    256\u001b[0m     overrides_list\u001b[39m=\u001b[39;49mparsed_overrides,\n\u001b[1;32m    257\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    258\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mrun_mode \u001b[39m==\u001b[39;49m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    259\u001b[0m )\n\u001b[1;32m    261\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[1;32m    263\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_compose_config_from_defaults_list(\n\u001b[1;32m    264\u001b[0m     defaults\u001b[39m=\u001b[39mdefaults_list\u001b[39m.\u001b[39mdefaults, repo\u001b[39m=\u001b[39mcaching_repo\n\u001b[1;32m    265\u001b[0m )\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:746\u001b[0m, in \u001b[0;36mcreate_defaults_list\u001b[0;34m(repo, config_name, overrides_list, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    737\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    738\u001b[0m \u001b[39m:param repo:\u001b[39;00m\n\u001b[1;32m    739\u001b[0m \u001b[39m:param config_name:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    743\u001b[0m \u001b[39m:return:\u001b[39;00m\n\u001b[1;32m    744\u001b[0m \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    745\u001b[0m overrides \u001b[39m=\u001b[39m Overrides(repo\u001b[39m=\u001b[39mrepo, overrides_list\u001b[39m=\u001b[39moverrides_list)\n\u001b[0;32m--> 746\u001b[0m defaults, tree \u001b[39m=\u001b[39m _create_defaults_list(\n\u001b[1;32m    747\u001b[0m     repo,\n\u001b[1;32m    748\u001b[0m     config_name,\n\u001b[1;32m    749\u001b[0m     overrides,\n\u001b[1;32m    750\u001b[0m     prepend_hydra\u001b[39m=\u001b[39;49mprepend_hydra,\n\u001b[1;32m    751\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    752\u001b[0m )\n\u001b[1;32m    753\u001b[0m overrides\u001b[39m.\u001b[39mensure_overrides_used()\n\u001b[1;32m    754\u001b[0m overrides\u001b[39m.\u001b[39mensure_deletions_used()\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:716\u001b[0m, in \u001b[0;36m_create_defaults_list\u001b[0;34m(repo, config_name, overrides, prepend_hydra, skip_missing)\u001b[0m\n\u001b[1;32m    706\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_create_defaults_list\u001b[39m(\n\u001b[1;32m    707\u001b[0m     repo: IConfigRepository,\n\u001b[1;32m    708\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    711\u001b[0m     skip_missing: \u001b[39mbool\u001b[39m,\n\u001b[1;32m    712\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m Tuple[List[ResultDefault], DefaultsTreeNode]:\n\u001b[1;32m    714\u001b[0m     root \u001b[39m=\u001b[39m _create_root(config_name\u001b[39m=\u001b[39mconfig_name, with_hydra\u001b[39m=\u001b[39mprepend_hydra)\n\u001b[0;32m--> 716\u001b[0m     defaults_tree \u001b[39m=\u001b[39m _create_defaults_tree(\n\u001b[1;32m    717\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    718\u001b[0m         root\u001b[39m=\u001b[39;49mroot,\n\u001b[1;32m    719\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    720\u001b[0m         is_root_config\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m,\n\u001b[1;32m    721\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    722\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    723\u001b[0m     )\n\u001b[1;32m    725\u001b[0m     output \u001b[39m=\u001b[39m _tree_to_list(tree\u001b[39m=\u001b[39mdefaults_tree)\n\u001b[1;32m    726\u001b[0m     ensure_no_duplicates_in_list(output)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:356\u001b[0m, in \u001b[0;36m_create_defaults_tree\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    348\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_create_defaults_tree\u001b[39m(\n\u001b[1;32m    349\u001b[0m     repo: IConfigRepository,\n\u001b[1;32m    350\u001b[0m     root: DefaultsTreeNode,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    354\u001b[0m     overrides: Overrides,\n\u001b[1;32m    355\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DefaultsTreeNode:\n\u001b[0;32m--> 356\u001b[0m     ret \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    357\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    358\u001b[0m         root\u001b[39m=\u001b[39;49mroot,\n\u001b[1;32m    359\u001b[0m         is_root_config\u001b[39m=\u001b[39;49mis_root_config,\n\u001b[1;32m    360\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    361\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49minterpolated_subtree,\n\u001b[1;32m    362\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    363\u001b[0m     )\n\u001b[1;32m    365\u001b[0m     \u001b[39mreturn\u001b[39;00m ret\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:457\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    455\u001b[0m \u001b[39mif\u001b[39;00m parent\u001b[39m.\u001b[39mis_virtual():\n\u001b[1;32m    456\u001b[0m     \u001b[39mif\u001b[39;00m is_root_config:\n\u001b[0;32m--> 457\u001b[0m         \u001b[39mreturn\u001b[39;00m _expand_virtual_root(repo, root, overrides, skip_missing)\n\u001b[1;32m    458\u001b[0m     \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    459\u001b[0m         \u001b[39mreturn\u001b[39;00m root\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:280\u001b[0m, in \u001b[0;36m_expand_virtual_root\u001b[0;34m(repo, root, overrides, skip_missing)\u001b[0m\n\u001b[1;32m    277\u001b[0m new_root \u001b[39m=\u001b[39m DefaultsTreeNode(node\u001b[39m=\u001b[39md, parent\u001b[39m=\u001b[39mroot)\n\u001b[1;32m    278\u001b[0m d\u001b[39m.\u001b[39mupdate_parent(\u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m, \u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m--> 280\u001b[0m subtree \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    281\u001b[0m     repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    282\u001b[0m     root\u001b[39m=\u001b[39;49mnew_root,\n\u001b[1;32m    283\u001b[0m     is_root_config\u001b[39m=\u001b[39;49md\u001b[39m.\u001b[39;49mprimary,\n\u001b[1;32m    284\u001b[0m     skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    285\u001b[0m     interpolated_subtree\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    286\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    287\u001b[0m )\n\u001b[1;32m    288\u001b[0m \u001b[39mif\u001b[39;00m subtree\u001b[39m.\u001b[39mchildren \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    289\u001b[0m     children\u001b[39m.\u001b[39mappend(d)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:573\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    570\u001b[0m                 \u001b[39mcontinue\u001b[39;00m\n\u001b[1;32m    572\u001b[0m             new_root \u001b[39m=\u001b[39m DefaultsTreeNode(node\u001b[39m=\u001b[39md, parent\u001b[39m=\u001b[39mroot)\n\u001b[0;32m--> 573\u001b[0m             add_child(children, new_root)\n\u001b[1;32m    575\u001b[0m \u001b[39m# processed deferred interpolations\u001b[39;00m\n\u001b[1;32m    576\u001b[0m known_choices \u001b[39m=\u001b[39m _create_interpolation_map(overrides, defaults_list, self_added)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:520\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl.<locals>.add_child\u001b[0;34m(child_list, new_root_)\u001b[0m\n\u001b[1;32m    516\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39madd_child\u001b[39m(\n\u001b[1;32m    517\u001b[0m     child_list: List[Union[InputDefault, DefaultsTreeNode]],\n\u001b[1;32m    518\u001b[0m     new_root_: DefaultsTreeNode,\n\u001b[1;32m    519\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 520\u001b[0m     subtree_ \u001b[39m=\u001b[39m _create_defaults_tree_impl(\n\u001b[1;32m    521\u001b[0m         repo\u001b[39m=\u001b[39;49mrepo,\n\u001b[1;32m    522\u001b[0m         root\u001b[39m=\u001b[39;49mnew_root_,\n\u001b[1;32m    523\u001b[0m         is_root_config\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    524\u001b[0m         interpolated_subtree\u001b[39m=\u001b[39;49minterpolated_subtree,\n\u001b[1;32m    525\u001b[0m         skip_missing\u001b[39m=\u001b[39;49mskip_missing,\n\u001b[1;32m    526\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    527\u001b[0m     )\n\u001b[1;32m    528\u001b[0m     \u001b[39mif\u001b[39;00m subtree_\u001b[39m.\u001b[39mchildren \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    529\u001b[0m         child_list\u001b[39m.\u001b[39mappend(new_root_\u001b[39m.\u001b[39mnode)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:488\u001b[0m, in \u001b[0;36m_create_defaults_tree_impl\u001b[0;34m(repo, root, is_root_config, skip_missing, interpolated_subtree, overrides)\u001b[0m\n\u001b[1;32m    486\u001b[0m         parent\u001b[39m.\u001b[39mdeleted \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m\n\u001b[1;32m    487\u001b[0m         \u001b[39mreturn\u001b[39;00m root\n\u001b[0;32m--> 488\u001b[0m     config_not_found_error(repo\u001b[39m=\u001b[39;49mrepo, tree\u001b[39m=\u001b[39;49mroot)\n\u001b[1;32m    490\u001b[0m \u001b[39massert\u001b[39;00m loaded \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    491\u001b[0m defaults_list \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(loaded\u001b[39m.\u001b[39mdefaults_list)\n",
-      "File \u001b[0;32m~/.local/lib/python3.8/site-packages/hydra/_internal/defaults_list.py:800\u001b[0m, in \u001b[0;36mconfig_not_found_error\u001b[0;34m(repo, tree)\u001b[0m\n\u001b[1;32m    797\u001b[0m lines \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39mjoin(descs)\n\u001b[1;32m    798\u001b[0m msg \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39mConfig search path:\u001b[39m\u001b[39m\"\u001b[39m \u001b[39m+\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00mlines\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 800\u001b[0m \u001b[39mraise\u001b[39;00m MissingConfigException(\n\u001b[1;32m    801\u001b[0m     missing_cfg_file\u001b[39m=\u001b[39melement\u001b[39m.\u001b[39mget_config_path(),\n\u001b[1;32m    802\u001b[0m     message\u001b[39m=\u001b[39mmsg,\n\u001b[1;32m    803\u001b[0m     options\u001b[39m=\u001b[39moptions,\n\u001b[1;32m    804\u001b[0m )\n",
-      "\u001b[0;31mMissingConfigException\u001b[0m: In 'zen_launch': Could not find 'lower_level_class/lower_level_class_3'\n\nConfig search path:\n\tprovider=hydra, path=pkg://hydra.conf\n\tprovider=schema, path=structured://"
-     ]
+     "data": {
+      "text/plain": [
+       "TopLevelClass(0, LowerLevelClass(99))"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -916,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -962,7 +978,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -971,7 +987,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), c='type 1', name_='llc_1', group_='llc_group', package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 55,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1002,7 +1018,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -1053,7 +1069,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
@@ -1087,9 +1103,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/alexnaka/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/defaults_list.py:251: UserWarning: In 'zen_launch': Defaults list is missing `_self_`. See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/default_composition_order for more information\n",
+      "  warnings.warn(msg, UserWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(123, MidLevelClass(1, LowerLevelClass(type 3)))"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "out = launch(\n",
     "    tlc_1, \n",
@@ -1100,9 +1135,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "TopLevelClass(123, MidLevelClass(1, LowerLevelClass(type 4)))"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "out = launch(\n",
     "    tlc_1, \n",
@@ -1114,7 +1160,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
@@ -1123,7 +1169,7 @@
        "TopLevelClass(123, MidLevelClass(1, LowerLevelClass(type X)))"
       ]
      },
-     "execution_count": 39,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1160,28 +1206,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 60,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "__init__() got an unexpected keyword argument 'b'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb Cell 52\u001b[0m in \u001b[0;36m<cell line: 1>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m \u001b[39mwith\u001b[39;00m ConfMode():\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m     LowerLevelClass(\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=2'>3</a>\u001b[0m         name_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class_5\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m         group_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=4'>5</a>\u001b[0m         b\u001b[39m=\u001b[39;49m\u001b[39m117\u001b[39;49m,\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=5'>6</a>\u001b[0m     )\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=6'>7</a>\u001b[0m     top_level_class_config_2 \u001b[39m=\u001b[39m TopLevelClass(\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=7'>8</a>\u001b[0m         a\u001b[39m=\u001b[39m\u001b[39m-\u001b[39m\u001b[39m9\u001b[39m,\n\u001b[1;32m      <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=8'>9</a>\u001b[0m         name_\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mtop_level_class_2\u001b[39m\u001b[39m'\u001b[39m, \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=11'>12</a>\u001b[0m             {\u001b[39m'\u001b[39m\u001b[39mlower_level_class\u001b[39m\u001b[39m'\u001b[39m: \u001b[39m'\u001b[39m\u001b[39mlower_level_class_5\u001b[39m\u001b[39m'\u001b[39m}]\n\u001b[1;32m     <a href='vscode-notebook-cell:/home/naka/code/hydra-zen/ipynb/add_conf_demo.ipynb#Y102sZmlsZQ%3D%3D?line=12'>13</a>\u001b[0m     )\n",
-      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:518\u001b[0m, in \u001b[0;36m_batteries_included_override_constructor.<locals>.WrappedClass.__new__\u001b[0;34m(cls, name_, group_, package_, provider_, defaults, *args, **kwargs)\u001b[0m\n\u001b[1;32m    516\u001b[0m \u001b[39mglobal\u001b[39;00m _configuring\n\u001b[1;32m    517\u001b[0m \u001b[39mif\u001b[39;00m _configuring:\n\u001b[0;32m--> 518\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mcls\u001b[39;49m\u001b[39m.\u001b[39;49mConf(\u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mzen_meta, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    519\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    520\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39msuper\u001b[39m(WrappedClass, \u001b[39mcls\u001b[39m)\u001b[39m.\u001b[39m\u001b[39m__new__\u001b[39m(\u001b[39mcls\u001b[39m)\n",
-      "\u001b[0;31mTypeError\u001b[0m: __init__() got an unexpected keyword argument 'b'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with ConfMode():\n",
     "    LowerLevelClass(\n",
     "        name_='lower_level_class_5',\n",
     "        group_='lower_level_class',\n",
-    "        b=117,\n",
+    "        c=117,\n",
     "    )\n",
     "    top_level_class_config_2 = TopLevelClass(\n",
     "        a=-9,\n",
@@ -1194,37 +1227,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/loyal/hydra-zen/src/hydra_zen/_launch.py:236: UserWarning: \n",
-      "The version_base parameter is not specified.\n",
-      "Please specify a compatability version level, or None.\n",
-      "Will assume defaults for version 1.1\n",
-      "  with initialize(\n",
-      "/home/ubuntu/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_4': Usage of deprecated keyword in package header '# @package _group_'.\n",
-      "See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
-      "  deprecation_warning(\n",
-      "/home/ubuntu/loyal/hydra-zen/src/hydra_zen/_launch.py:270: UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.\n",
-      "See https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information.\n",
-      "  job = run_job(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "TopLevelClass(-9, LowerLevelClass(99))"
-      ]
-     },
-     "execution_count": 81,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "out = launch(\n",
     "    top_level_class_config_2, \n",
@@ -1236,27 +1241,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_5': Usage of deprecated keyword in package header '# @package _group_'.\n",
-      "See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
-      "  deprecation_warning(\n"
+     "ename": "ConfigCompositionException",
+     "evalue": "In 'lower_level_class/lower_level_class_5': ConfigKeyError raised while composing config:\nKey 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mConfigKeyError\u001b[0m                            Traceback (most recent call last)",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:542\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    541\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 542\u001b[0m     cfg\u001b[39m.\u001b[39;49mmerge_with(loaded\u001b[39m.\u001b[39;49mconfig)\n\u001b[1;32m    543\u001b[0m \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:492\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 492\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(key\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, value\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, cause\u001b[39m=\u001b[39;49me)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:490\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    489\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 490\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_merge_with(\u001b[39m*\u001b[39;49mothers)\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:514\u001b[0m, in \u001b[0;36mBaseContainer._merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    513\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, DictConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, DictConfig):\n\u001b[0;32m--> 514\u001b[0m     BaseContainer\u001b[39m.\u001b[39;49m_map_merge(\u001b[39mself\u001b[39;49m, other)\n\u001b[1;32m    515\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, ListConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, ListConfig):\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:432\u001b[0m, in \u001b[0;36mBaseContainer._map_merge\u001b[0;34m(dest, src)\u001b[0m\n\u001b[1;32m    431\u001b[0m         \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 432\u001b[0m             dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    434\u001b[0m _update_types(node\u001b[39m=\u001b[39mdest, ref_type\u001b[39m=\u001b[39msrc_ref_type, object_type\u001b[39m=\u001b[39msrc_type)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:310\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 310\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    311\u001b[0m         key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, type_override\u001b[39m=\u001b[39;49mConfigKeyError, cause\u001b[39m=\u001b[39;49me\n\u001b[1;32m    312\u001b[0m     )\n\u001b[1;32m    313\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:308\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    307\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 308\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m__set_impl(key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue)\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:318\u001b[0m, in \u001b[0;36mDictConfig.__set_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    317\u001b[0m key \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_and_normalize_key(key)\n\u001b[0;32m--> 318\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_set_item_impl(key, value)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:545\u001b[0m, in \u001b[0;36mBaseContainer._set_item_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    544\u001b[0m     value\u001b[39m.\u001b[39m_set_key(key)\n\u001b[0;32m--> 545\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_set(key, value)\n\u001b[1;32m    546\u001b[0m \u001b[39mfinally\u001b[39;00m:\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:180\u001b[0m, in \u001b[0;36mDictConfig._validate_set\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    178\u001b[0m     \u001b[39mreturn\u001b[39;00m\n\u001b[0;32m--> 180\u001b[0m target \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_node(key) \u001b[39mif\u001b[39;00m key \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39melse\u001b[39;00m \u001b[39mself\u001b[39m\n\u001b[1;32m    182\u001b[0m target_has_ref_type \u001b[39m=\u001b[39m \u001b[39misinstance\u001b[39m(\n\u001b[1;32m    183\u001b[0m     target, DictConfig\n\u001b[1;32m    184\u001b[0m ) \u001b[39mand\u001b[39;00m target\u001b[39m.\u001b[39m_metadata\u001b[39m.\u001b[39mref_type \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m (Any, \u001b[39mdict\u001b[39m)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:475\u001b[0m, in \u001b[0;36mDictConfig._get_node\u001b[0;34m(self, key, validate_access, validate_key, throw_on_missing_value, throw_on_missing_key)\u001b[0m\n\u001b[1;32m    474\u001b[0m \u001b[39mif\u001b[39;00m validate_access:\n\u001b[0;32m--> 475\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_get(key)\n\u001b[1;32m    477\u001b[0m value: Optional[Node] \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m[\u001b[39m\"\u001b[39m\u001b[39m_content\u001b[39m\u001b[39m\"\u001b[39m]\u001b[39m.\u001b[39mget(key)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:164\u001b[0m, in \u001b[0;36mDictConfig._validate_get\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    163\u001b[0m     msg \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mKey \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mkey\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m is not in struct\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 164\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    165\u001b[0m     key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, cause\u001b[39m=\u001b[39;49mConfigAttributeError(msg)\n\u001b[1;32m    166\u001b[0m )\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:899\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    897\u001b[0m     ex\u001b[39m.\u001b[39mref_type_str \u001b[39m=\u001b[39m ref_type_str\n\u001b[0;32m--> 899\u001b[0m _raise(ex, cause)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "\u001b[0;31mConfigKeyError\u001b[0m: Key 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mConfigCompositionException\u001b[0m                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[26], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m out \u001b[39m=\u001b[39m launch(\n\u001b[1;32m      2\u001b[0m     top_level_class_config_2, \n\u001b[1;32m      3\u001b[0m     launch_and_instantiate, \n\u001b[1;32m      4\u001b[0m     overrides\u001b[39m=\u001b[39;49m[\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class.b=123\u001b[39;49m\u001b[39m'\u001b[39;49m]\n\u001b[1;32m      5\u001b[0m     )\n\u001b[1;32m      6\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
+      "File \u001b[0;32m~/code/hydra-zen/src/hydra_zen/_launch.py:251\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    250\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> 251\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    252\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    253\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    254\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    255\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    256\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    257\u001b[0m )\n\u001b[1;32m    259\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    260\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    261\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    262\u001b[0m )\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    576\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    577\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    578\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    583\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    584\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    585\u001b[0m     \u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    586\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    587\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    591\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    592\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 594\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    595\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    596\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    597\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    598\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    599\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    600\u001b[0m     )\n\u001b[1;32m    601\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    602\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:142\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    133\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    134\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    135\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    139\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    140\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    141\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 142\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    143\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    144\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    145\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    146\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    147\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    148\u001b[0m         )\n\u001b[1;32m    149\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    150\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:263\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    253\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    254\u001b[0m     repo\u001b[39m=\u001b[39mcaching_repo,\n\u001b[1;32m    255\u001b[0m     config_name\u001b[39m=\u001b[39mconfig_name,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    258\u001b[0m     skip_missing\u001b[39m=\u001b[39mrun_mode \u001b[39m==\u001b[39m RunMode\u001b[39m.\u001b[39mMULTIRUN,\n\u001b[1;32m    259\u001b[0m )\n\u001b[1;32m    261\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[0;32m--> 263\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_compose_config_from_defaults_list(\n\u001b[1;32m    264\u001b[0m     defaults\u001b[39m=\u001b[39;49mdefaults_list\u001b[39m.\u001b[39;49mdefaults, repo\u001b[39m=\u001b[39;49mcaching_repo\n\u001b[1;32m    265\u001b[0m )\n\u001b[1;32m    267\u001b[0m \u001b[39m# Set config root to struct mode.\u001b[39;00m\n\u001b[1;32m    268\u001b[0m \u001b[39m# Note that this will close any dictionaries (including dicts annotated as Dict[K, V].\u001b[39;00m\n\u001b[1;32m    269\u001b[0m \u001b[39m# One must use + to add new fields to them.\u001b[39;00m\n\u001b[1;32m    270\u001b[0m OmegaConf\u001b[39m.\u001b[39mset_struct(cfg, \u001b[39mTrue\u001b[39;00m)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:544\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    542\u001b[0m             cfg\u001b[39m.\u001b[39mmerge_with(loaded\u001b[39m.\u001b[39mconfig)\n\u001b[1;32m    543\u001b[0m         \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 544\u001b[0m             \u001b[39mraise\u001b[39;00m ConfigCompositionException(\n\u001b[1;32m    545\u001b[0m                 \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mIn \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mdefault\u001b[39m.\u001b[39mconfig_path\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m: \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mtype\u001b[39m(e)\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m raised while\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    546\u001b[0m                 \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m composing config:\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00me\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[1;32m    547\u001b[0m             )\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n\u001b[1;32m    549\u001b[0m \u001b[39m# # remove remaining defaults lists from all nodes.\u001b[39;00m\n\u001b[1;32m    550\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mstrip_defaults\u001b[39m(cfg: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:542\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    540\u001b[0m loaded \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_load_single_config(default\u001b[39m=\u001b[39mdefault, repo\u001b[39m=\u001b[39mrepo)\n\u001b[1;32m    541\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 542\u001b[0m     cfg\u001b[39m.\u001b[39;49mmerge_with(loaded\u001b[39m.\u001b[39;49mconfig)\n\u001b[1;32m    543\u001b[0m \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    544\u001b[0m     \u001b[39mraise\u001b[39;00m ConfigCompositionException(\n\u001b[1;32m    545\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mIn \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mdefault\u001b[39m.\u001b[39mconfig_path\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m: \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mtype\u001b[39m(e)\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m raised while\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    546\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m composing config:\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00me\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[1;32m    547\u001b[0m     )\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:492\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    490\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_merge_with(\u001b[39m*\u001b[39mothers)\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 492\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(key\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, value\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, cause\u001b[39m=\u001b[39;49me)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    817\u001b[0m         ex \u001b[39m=\u001b[39m type_override(\u001b[39mstr\u001b[39m(cause))\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n\u001b[1;32m    822\u001b[0m object_type_str: Optional[\u001b[39mstr\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:490\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    483\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mmerge_with\u001b[39m(\n\u001b[1;32m    484\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    485\u001b[0m     \u001b[39m*\u001b[39mothers: Union[\n\u001b[1;32m    486\u001b[0m         \u001b[39m\"\u001b[39m\u001b[39mBaseContainer\u001b[39m\u001b[39m\"\u001b[39m, Dict[\u001b[39mstr\u001b[39m, Any], List[Any], Tuple[Any, \u001b[39m.\u001b[39m\u001b[39m.\u001b[39m\u001b[39m.\u001b[39m], Any\n\u001b[1;32m    487\u001b[0m     ],\n\u001b[1;32m    488\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    489\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 490\u001b[0m         \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_merge_with(\u001b[39m*\u001b[39;49mothers)\n\u001b[1;32m    491\u001b[0m     \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    492\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(key\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m, value\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m, cause\u001b[39m=\u001b[39me)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:514\u001b[0m, in \u001b[0;36mBaseContainer._merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    511\u001b[0m other \u001b[39m=\u001b[39m _ensure_container(other, flags\u001b[39m=\u001b[39mmy_flags)\n\u001b[1;32m    513\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, DictConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, DictConfig):\n\u001b[0;32m--> 514\u001b[0m     BaseContainer\u001b[39m.\u001b[39;49m_map_merge(\u001b[39mself\u001b[39;49m, other)\n\u001b[1;32m    515\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, ListConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, ListConfig):\n\u001b[1;32m    516\u001b[0m     BaseContainer\u001b[39m.\u001b[39m_list_merge(\u001b[39mself\u001b[39m, other)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:432\u001b[0m, in \u001b[0;36mBaseContainer._map_merge\u001b[0;34m(dest, src)\u001b[0m\n\u001b[1;32m    430\u001b[0m                 dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    431\u001b[0m         \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 432\u001b[0m             dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    434\u001b[0m _update_types(node\u001b[39m=\u001b[39mdest, ref_type\u001b[39m=\u001b[39msrc_ref_type, object_type\u001b[39m=\u001b[39msrc_type)\n\u001b[1;32m    436\u001b[0m \u001b[39m# explicit flags on the source config are replacing the flag values in the destination\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:310\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    308\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m__set_impl(key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue)\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 310\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    311\u001b[0m         key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, type_override\u001b[39m=\u001b[39;49mConfigKeyError, cause\u001b[39m=\u001b[39;49me\n\u001b[1;32m    312\u001b[0m     )\n\u001b[1;32m    313\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    314\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue, cause\u001b[39m=\u001b[39me)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    817\u001b[0m         ex \u001b[39m=\u001b[39m type_override(\u001b[39mstr\u001b[39m(cause))\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n\u001b[1;32m    822\u001b[0m object_type_str: Optional[\u001b[39mstr\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:308\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    306\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__setitem__\u001b[39m(\u001b[39mself\u001b[39m, key: DictKeyType, value: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    307\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 308\u001b[0m         \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m__set_impl(key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue)\n\u001b[1;32m    309\u001b[0m     \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    310\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(\n\u001b[1;32m    311\u001b[0m             key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue, type_override\u001b[39m=\u001b[39mConfigKeyError, cause\u001b[39m=\u001b[39me\n\u001b[1;32m    312\u001b[0m         )\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:318\u001b[0m, in \u001b[0;36mDictConfig.__set_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    316\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__set_impl\u001b[39m(\u001b[39mself\u001b[39m, key: DictKeyType, value: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    317\u001b[0m     key \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_and_normalize_key(key)\n\u001b[0;32m--> 318\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_set_item_impl(key, value)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:545\u001b[0m, in \u001b[0;36mBaseContainer._set_item_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    543\u001b[0m     old \u001b[39m=\u001b[39m value\u001b[39m.\u001b[39m_key()\n\u001b[1;32m    544\u001b[0m     value\u001b[39m.\u001b[39m_set_key(key)\n\u001b[0;32m--> 545\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_set(key, value)\n\u001b[1;32m    546\u001b[0m \u001b[39mfinally\u001b[39;00m:\n\u001b[1;32m    547\u001b[0m     value\u001b[39m.\u001b[39m_set_key(old)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:180\u001b[0m, in \u001b[0;36mDictConfig._validate_set\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    177\u001b[0m \u001b[39mif\u001b[39;00m vk \u001b[39m==\u001b[39m ValueKind\u001b[39m.\u001b[39mMANDATORY_MISSING \u001b[39mor\u001b[39;00m value \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    178\u001b[0m     \u001b[39mreturn\u001b[39;00m\n\u001b[0;32m--> 180\u001b[0m target \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_node(key) \u001b[39mif\u001b[39;00m key \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39melse\u001b[39;00m \u001b[39mself\u001b[39m\n\u001b[1;32m    182\u001b[0m target_has_ref_type \u001b[39m=\u001b[39m \u001b[39misinstance\u001b[39m(\n\u001b[1;32m    183\u001b[0m     target, DictConfig\n\u001b[1;32m    184\u001b[0m ) \u001b[39mand\u001b[39;00m target\u001b[39m.\u001b[39m_metadata\u001b[39m.\u001b[39mref_type \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m (Any, \u001b[39mdict\u001b[39m)\n\u001b[1;32m    185\u001b[0m is_valid_target \u001b[39m=\u001b[39m target \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39mor\u001b[39;00m \u001b[39mnot\u001b[39;00m target_has_ref_type\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:475\u001b[0m, in \u001b[0;36mDictConfig._get_node\u001b[0;34m(self, key, validate_access, validate_key, throw_on_missing_value, throw_on_missing_key)\u001b[0m\n\u001b[1;32m    472\u001b[0m             \u001b[39mreturn\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    474\u001b[0m \u001b[39mif\u001b[39;00m validate_access:\n\u001b[0;32m--> 475\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_get(key)\n\u001b[1;32m    477\u001b[0m value: Optional[Node] \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m[\u001b[39m\"\u001b[39m\u001b[39m_content\u001b[39m\u001b[39m\"\u001b[39m]\u001b[39m.\u001b[39mget(key)\n\u001b[1;32m    478\u001b[0m \u001b[39mif\u001b[39;00m value \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:164\u001b[0m, in \u001b[0;36mDictConfig._validate_get\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    162\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    163\u001b[0m     msg \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mKey \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mkey\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m is not in struct\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 164\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    165\u001b[0m     key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, cause\u001b[39m=\u001b[39;49mConfigAttributeError(msg)\n\u001b[1;32m    166\u001b[0m )\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:899\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    896\u001b[0m     ex\u001b[39m.\u001b[39mref_type \u001b[39m=\u001b[39m ref_type\n\u001b[1;32m    897\u001b[0m     ex\u001b[39m.\u001b[39mref_type_str \u001b[39m=\u001b[39m ref_type_str\n\u001b[0;32m--> 899\u001b[0m _raise(ex, cause)\n",
+      "File \u001b[0;32m~/opt/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "\u001b[0;31mConfigCompositionException\u001b[0m: In 'lower_level_class/lower_level_class_5': ConfigKeyError raised while composing config:\nKey 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass"
      ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "TopLevelClass(-9, LowerLevelClass(123))"
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1899,7 +1946,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "newtricks",
+   "display_name": "hydra-zen",
    "language": "python",
    "name": "python3"
   },
@@ -1913,12 +1960,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.8"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "f2b5ce3424cfe828ef4e1c95261b27483fb5e8064e6ac1b9427b271ef41a820d"
+    "hash": "88a4ed8af8cb773a7548eaacdd81221c698b9e61453d4d803a646964ee64d212"
    }
   }
  },

--- a/ipynb/add_conf_demo.ipynb
+++ b/ipynb/add_conf_demo.ipynb
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 98,
    "metadata": {},
    "outputs": [
     {
@@ -71,7 +71,7 @@
        "MyClass(dog, 3)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 98,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 99,
    "metadata": {},
    "outputs": [
     {
@@ -104,7 +104,7 @@
        "types.Builds_MyClass"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 99,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 85,
    "metadata": {},
    "outputs": [
     {
@@ -125,7 +125,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='dog', b=3, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 85,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -138,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 101,
    "metadata": {},
    "outputs": [
     {
@@ -147,7 +147,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 101,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -159,16 +159,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 103,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "MyClass(dog, 3)"
+       "'_target_: hydra_zen.funcs.zen_processing\\n_zen_target: __main__.MyClass\\n_zen_exclude:\\n- name_\\n- group_\\n- package_\\n- provider_\\n- defaults\\n_recursive_: false\\na: dog\\nb: 3\\nname_: null\\ngroup_: null\\npackage_: _group_\\nprovider_: null\\ndefaults:\\n- _self_\\n'"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 103,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -180,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 88,
    "metadata": {},
    "outputs": [
     {
@@ -189,7 +189,7 @@
        "MyClass(Bloom, 3)"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 88,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -201,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 89,
    "metadata": {},
    "outputs": [
     {
@@ -210,7 +210,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 89,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -229,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 90,
    "metadata": {},
    "outputs": [
     {
@@ -238,7 +238,7 @@
        "MyClass(Lily, 3)"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 90,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -250,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 91,
    "metadata": {},
    "outputs": [
     {
@@ -259,7 +259,7 @@
        "MyClass(Lily, 3)"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 91,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -271,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 92,
    "metadata": {},
    "outputs": [
     {
@@ -280,7 +280,7 @@
        "MyClass(Bloom, 47)"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 92,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -294,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 95,
    "metadata": {},
    "outputs": [
     {
@@ -303,7 +303,7 @@
        "MyClass(Bloom, 117)"
       ]
      },
-     "execution_count": 35,
+     "execution_count": 95,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -317,22 +317,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 96,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "True"
+       "MyClass(Lily, 117)"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 96,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "my_class.conf.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 100,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "issubclass(MyClass.Conf,ZenExtras)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 97,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "isinstance(my_class.conf,ZenExtras)"
    ]
   },
   {
@@ -1125,22 +1165,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 79,
+   "execution_count": 80,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "TypeError",
-     "evalue": "Builds_LowerLevelClass.__init__() got an unexpected keyword argument 'c'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[79], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mwith\u001b[39;00m ConfMode():\n\u001b[0;32m----> 2\u001b[0m     LowerLevelClass(\n\u001b[1;32m      3\u001b[0m         name_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class_5\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      4\u001b[0m         group_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      5\u001b[0m         c\u001b[39m=\u001b[39;49m\u001b[39m117\u001b[39;49m,\n\u001b[1;32m      6\u001b[0m     )\n\u001b[1;32m      7\u001b[0m     top_level_class_config_2 \u001b[39m=\u001b[39m TopLevelClass(\n\u001b[1;32m      8\u001b[0m         a\u001b[39m=\u001b[39m\u001b[39m-\u001b[39m\u001b[39m9\u001b[39m,\n\u001b[1;32m      9\u001b[0m         name_\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mtop_level_class_2\u001b[39m\u001b[39m'\u001b[39m, \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     12\u001b[0m             {\u001b[39m'\u001b[39m\u001b[39mlower_level_class\u001b[39m\u001b[39m'\u001b[39m: \u001b[39m'\u001b[39m\u001b[39mlower_level_class_5\u001b[39m\u001b[39m'\u001b[39m}]\n\u001b[1;32m     13\u001b[0m     )\n",
-      "File \u001b[0;32m~/loyal/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:205\u001b[0m, in \u001b[0;36moverride_constructor.<locals>.WrappedClass.__new__\u001b[0;34m(cls, name_, group_, package_, provider_, defaults, *args, **kwargs)\u001b[0m\n\u001b[1;32m    203\u001b[0m \u001b[39mglobal\u001b[39;00m _configuring\n\u001b[1;32m    204\u001b[0m \u001b[39mif\u001b[39;00m _configuring:\n\u001b[0;32m--> 205\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mcls\u001b[39;49m\u001b[39m.\u001b[39;49mConf(\u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mzen_meta, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    206\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    207\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39msuper\u001b[39m(WrappedClass, \u001b[39mcls\u001b[39m)\u001b[39m.\u001b[39m\u001b[39m__new__\u001b[39m(\u001b[39mcls\u001b[39m)\n",
-      "\u001b[0;31mTypeError\u001b[0m: Builds_LowerLevelClass.__init__() got an unexpected keyword argument 'c'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with ConfMode():\n",
     "    LowerLevelClass(\n",
@@ -1159,7 +1186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 66,
+   "execution_count": 81,
    "metadata": {},
    "outputs": [
     {
@@ -1173,69 +1200,21 @@
       "  with initialize(\n",
       "/home/ubuntu/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_4': Usage of deprecated keyword in package header '# @package _group_'.\n",
       "See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
-      "  deprecation_warning(\n"
+      "  deprecation_warning(\n",
+      "/home/ubuntu/loyal/hydra-zen/src/hydra_zen/_launch.py:270: UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.\n",
+      "See https://hydra.cc/docs/1.2/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information.\n",
+      "  job = run_job(\n"
      ]
     },
     {
-     "ename": "ConfigCompositionException",
-     "evalue": "In 'lower_level_class/lower_level_class_4': ConfigKeyError raised while composing config:\nKey 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mConfigKeyError\u001b[0m                            Traceback (most recent call last)",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:542\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    541\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 542\u001b[0m     cfg\u001b[39m.\u001b[39;49mmerge_with(loaded\u001b[39m.\u001b[39;49mconfig)\n\u001b[1;32m    543\u001b[0m \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:492\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 492\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(key\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, value\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, cause\u001b[39m=\u001b[39;49me)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:490\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    489\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 490\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_merge_with(\u001b[39m*\u001b[39;49mothers)\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:514\u001b[0m, in \u001b[0;36mBaseContainer._merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    513\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, DictConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, DictConfig):\n\u001b[0;32m--> 514\u001b[0m     BaseContainer\u001b[39m.\u001b[39;49m_map_merge(\u001b[39mself\u001b[39;49m, other)\n\u001b[1;32m    515\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, ListConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, ListConfig):\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:432\u001b[0m, in \u001b[0;36mBaseContainer._map_merge\u001b[0;34m(dest, src)\u001b[0m\n\u001b[1;32m    431\u001b[0m         \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 432\u001b[0m             dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    434\u001b[0m _update_types(node\u001b[39m=\u001b[39mdest, ref_type\u001b[39m=\u001b[39msrc_ref_type, object_type\u001b[39m=\u001b[39msrc_type)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:310\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 310\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    311\u001b[0m         key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, type_override\u001b[39m=\u001b[39;49mConfigKeyError, cause\u001b[39m=\u001b[39;49me\n\u001b[1;32m    312\u001b[0m     )\n\u001b[1;32m    313\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:308\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    307\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 308\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m__set_impl(key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue)\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:318\u001b[0m, in \u001b[0;36mDictConfig.__set_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    317\u001b[0m key \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_and_normalize_key(key)\n\u001b[0;32m--> 318\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_set_item_impl(key, value)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:545\u001b[0m, in \u001b[0;36mBaseContainer._set_item_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    544\u001b[0m     value\u001b[39m.\u001b[39m_set_key(key)\n\u001b[0;32m--> 545\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_set(key, value)\n\u001b[1;32m    546\u001b[0m \u001b[39mfinally\u001b[39;00m:\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:180\u001b[0m, in \u001b[0;36mDictConfig._validate_set\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    178\u001b[0m     \u001b[39mreturn\u001b[39;00m\n\u001b[0;32m--> 180\u001b[0m target \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_node(key) \u001b[39mif\u001b[39;00m key \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39melse\u001b[39;00m \u001b[39mself\u001b[39m\n\u001b[1;32m    182\u001b[0m target_has_ref_type \u001b[39m=\u001b[39m \u001b[39misinstance\u001b[39m(\n\u001b[1;32m    183\u001b[0m     target, DictConfig\n\u001b[1;32m    184\u001b[0m ) \u001b[39mand\u001b[39;00m target\u001b[39m.\u001b[39m_metadata\u001b[39m.\u001b[39mref_type \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m (Any, \u001b[39mdict\u001b[39m)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:475\u001b[0m, in \u001b[0;36mDictConfig._get_node\u001b[0;34m(self, key, validate_access, validate_key, throw_on_missing_value, throw_on_missing_key)\u001b[0m\n\u001b[1;32m    474\u001b[0m \u001b[39mif\u001b[39;00m validate_access:\n\u001b[0;32m--> 475\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_get(key)\n\u001b[1;32m    477\u001b[0m value: Optional[Node] \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m[\u001b[39m\"\u001b[39m\u001b[39m_content\u001b[39m\u001b[39m\"\u001b[39m]\u001b[39m.\u001b[39mget(key)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:164\u001b[0m, in \u001b[0;36mDictConfig._validate_get\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    163\u001b[0m     msg \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mKey \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mkey\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m is not in struct\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 164\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    165\u001b[0m     key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, cause\u001b[39m=\u001b[39;49mConfigAttributeError(msg)\n\u001b[1;32m    166\u001b[0m )\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:899\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    897\u001b[0m     ex\u001b[39m.\u001b[39mref_type_str \u001b[39m=\u001b[39m ref_type_str\n\u001b[0;32m--> 899\u001b[0m _raise(ex, cause)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
-      "\u001b[0;31mConfigKeyError\u001b[0m: Key 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mConfigCompositionException\u001b[0m                Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[66], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m out \u001b[39m=\u001b[39m launch(\n\u001b[1;32m      2\u001b[0m     top_level_class_config_2, \n\u001b[1;32m      3\u001b[0m     launch_and_instantiate, \n\u001b[1;32m      4\u001b[0m     overrides\u001b[39m=\u001b[39;49m[\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class=lower_level_class_4\u001b[39;49m\u001b[39m'\u001b[39;49m]\n\u001b[1;32m      5\u001b[0m     )\n\u001b[1;32m      6\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
-      "File \u001b[0;32m~/loyal/hydra-zen/src/hydra_zen/_launch.py:251\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    250\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> 251\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    252\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    253\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    254\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    255\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    256\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    257\u001b[0m )\n\u001b[1;32m    259\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    260\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    261\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    262\u001b[0m )\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    576\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    577\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    578\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    583\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    584\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    585\u001b[0m \u001b[39m    \u001b[39m\u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    586\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    587\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    591\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    592\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 594\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    595\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    596\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    597\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    598\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    599\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    600\u001b[0m     )\n\u001b[1;32m    601\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    602\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:142\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    133\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    134\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    135\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    139\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    140\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    141\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 142\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    143\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    144\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    145\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    146\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    147\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    148\u001b[0m         )\n\u001b[1;32m    149\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    150\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:263\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    253\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    254\u001b[0m     repo\u001b[39m=\u001b[39mcaching_repo,\n\u001b[1;32m    255\u001b[0m     config_name\u001b[39m=\u001b[39mconfig_name,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    258\u001b[0m     skip_missing\u001b[39m=\u001b[39mrun_mode \u001b[39m==\u001b[39m RunMode\u001b[39m.\u001b[39mMULTIRUN,\n\u001b[1;32m    259\u001b[0m )\n\u001b[1;32m    261\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[0;32m--> 263\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_compose_config_from_defaults_list(\n\u001b[1;32m    264\u001b[0m     defaults\u001b[39m=\u001b[39;49mdefaults_list\u001b[39m.\u001b[39;49mdefaults, repo\u001b[39m=\u001b[39;49mcaching_repo\n\u001b[1;32m    265\u001b[0m )\n\u001b[1;32m    267\u001b[0m \u001b[39m# Set config root to struct mode.\u001b[39;00m\n\u001b[1;32m    268\u001b[0m \u001b[39m# Note that this will close any dictionaries (including dicts annotated as Dict[K, V].\u001b[39;00m\n\u001b[1;32m    269\u001b[0m \u001b[39m# One must use + to add new fields to them.\u001b[39;00m\n\u001b[1;32m    270\u001b[0m OmegaConf\u001b[39m.\u001b[39mset_struct(cfg, \u001b[39mTrue\u001b[39;00m)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:544\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    542\u001b[0m             cfg\u001b[39m.\u001b[39mmerge_with(loaded\u001b[39m.\u001b[39mconfig)\n\u001b[1;32m    543\u001b[0m         \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 544\u001b[0m             \u001b[39mraise\u001b[39;00m ConfigCompositionException(\n\u001b[1;32m    545\u001b[0m                 \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mIn \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mdefault\u001b[39m.\u001b[39mconfig_path\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m: \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mtype\u001b[39m(e)\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m raised while\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    546\u001b[0m                 \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m composing config:\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00me\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[1;32m    547\u001b[0m             )\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n\u001b[1;32m    549\u001b[0m \u001b[39m# # remove remaining defaults lists from all nodes.\u001b[39;00m\n\u001b[1;32m    550\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mstrip_defaults\u001b[39m(cfg: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:542\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    540\u001b[0m loaded \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_load_single_config(default\u001b[39m=\u001b[39mdefault, repo\u001b[39m=\u001b[39mrepo)\n\u001b[1;32m    541\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 542\u001b[0m     cfg\u001b[39m.\u001b[39;49mmerge_with(loaded\u001b[39m.\u001b[39;49mconfig)\n\u001b[1;32m    543\u001b[0m \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    544\u001b[0m     \u001b[39mraise\u001b[39;00m ConfigCompositionException(\n\u001b[1;32m    545\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mIn \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mdefault\u001b[39m.\u001b[39mconfig_path\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m: \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mtype\u001b[39m(e)\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m raised while\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    546\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m composing config:\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00me\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[1;32m    547\u001b[0m     )\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:492\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    490\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_merge_with(\u001b[39m*\u001b[39mothers)\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 492\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(key\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, value\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, cause\u001b[39m=\u001b[39;49me)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    817\u001b[0m         ex \u001b[39m=\u001b[39m type_override(\u001b[39mstr\u001b[39m(cause))\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n\u001b[1;32m    822\u001b[0m object_type_str: Optional[\u001b[39mstr\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:490\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    483\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mmerge_with\u001b[39m(\n\u001b[1;32m    484\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    485\u001b[0m     \u001b[39m*\u001b[39mothers: Union[\n\u001b[1;32m    486\u001b[0m         \u001b[39m\"\u001b[39m\u001b[39mBaseContainer\u001b[39m\u001b[39m\"\u001b[39m, Dict[\u001b[39mstr\u001b[39m, Any], List[Any], Tuple[Any, \u001b[39m.\u001b[39m\u001b[39m.\u001b[39m\u001b[39m.\u001b[39m], Any\n\u001b[1;32m    487\u001b[0m     ],\n\u001b[1;32m    488\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    489\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 490\u001b[0m         \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_merge_with(\u001b[39m*\u001b[39;49mothers)\n\u001b[1;32m    491\u001b[0m     \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    492\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(key\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m, value\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m, cause\u001b[39m=\u001b[39me)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:514\u001b[0m, in \u001b[0;36mBaseContainer._merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    511\u001b[0m other \u001b[39m=\u001b[39m _ensure_container(other, flags\u001b[39m=\u001b[39mmy_flags)\n\u001b[1;32m    513\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, DictConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, DictConfig):\n\u001b[0;32m--> 514\u001b[0m     BaseContainer\u001b[39m.\u001b[39;49m_map_merge(\u001b[39mself\u001b[39;49m, other)\n\u001b[1;32m    515\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, ListConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, ListConfig):\n\u001b[1;32m    516\u001b[0m     BaseContainer\u001b[39m.\u001b[39m_list_merge(\u001b[39mself\u001b[39m, other)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:432\u001b[0m, in \u001b[0;36mBaseContainer._map_merge\u001b[0;34m(dest, src)\u001b[0m\n\u001b[1;32m    430\u001b[0m                 dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    431\u001b[0m         \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 432\u001b[0m             dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    434\u001b[0m _update_types(node\u001b[39m=\u001b[39mdest, ref_type\u001b[39m=\u001b[39msrc_ref_type, object_type\u001b[39m=\u001b[39msrc_type)\n\u001b[1;32m    436\u001b[0m \u001b[39m# explicit flags on the source config are replacing the flag values in the destination\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:310\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    308\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m__set_impl(key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue)\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 310\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    311\u001b[0m         key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, type_override\u001b[39m=\u001b[39;49mConfigKeyError, cause\u001b[39m=\u001b[39;49me\n\u001b[1;32m    312\u001b[0m     )\n\u001b[1;32m    313\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    314\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue, cause\u001b[39m=\u001b[39me)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    817\u001b[0m         ex \u001b[39m=\u001b[39m type_override(\u001b[39mstr\u001b[39m(cause))\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n\u001b[1;32m    822\u001b[0m object_type_str: Optional[\u001b[39mstr\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:308\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    306\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__setitem__\u001b[39m(\u001b[39mself\u001b[39m, key: DictKeyType, value: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    307\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 308\u001b[0m         \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m__set_impl(key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue)\n\u001b[1;32m    309\u001b[0m     \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    310\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(\n\u001b[1;32m    311\u001b[0m             key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue, type_override\u001b[39m=\u001b[39mConfigKeyError, cause\u001b[39m=\u001b[39me\n\u001b[1;32m    312\u001b[0m         )\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:318\u001b[0m, in \u001b[0;36mDictConfig.__set_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    316\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__set_impl\u001b[39m(\u001b[39mself\u001b[39m, key: DictKeyType, value: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    317\u001b[0m     key \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_and_normalize_key(key)\n\u001b[0;32m--> 318\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_set_item_impl(key, value)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:545\u001b[0m, in \u001b[0;36mBaseContainer._set_item_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    543\u001b[0m     old \u001b[39m=\u001b[39m value\u001b[39m.\u001b[39m_key()\n\u001b[1;32m    544\u001b[0m     value\u001b[39m.\u001b[39m_set_key(key)\n\u001b[0;32m--> 545\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_set(key, value)\n\u001b[1;32m    546\u001b[0m \u001b[39mfinally\u001b[39;00m:\n\u001b[1;32m    547\u001b[0m     value\u001b[39m.\u001b[39m_set_key(old)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:180\u001b[0m, in \u001b[0;36mDictConfig._validate_set\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    177\u001b[0m \u001b[39mif\u001b[39;00m vk \u001b[39m==\u001b[39m ValueKind\u001b[39m.\u001b[39mMANDATORY_MISSING \u001b[39mor\u001b[39;00m value \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    178\u001b[0m     \u001b[39mreturn\u001b[39;00m\n\u001b[0;32m--> 180\u001b[0m target \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_node(key) \u001b[39mif\u001b[39;00m key \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39melse\u001b[39;00m \u001b[39mself\u001b[39m\n\u001b[1;32m    182\u001b[0m target_has_ref_type \u001b[39m=\u001b[39m \u001b[39misinstance\u001b[39m(\n\u001b[1;32m    183\u001b[0m     target, DictConfig\n\u001b[1;32m    184\u001b[0m ) \u001b[39mand\u001b[39;00m target\u001b[39m.\u001b[39m_metadata\u001b[39m.\u001b[39mref_type \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m (Any, \u001b[39mdict\u001b[39m)\n\u001b[1;32m    185\u001b[0m is_valid_target \u001b[39m=\u001b[39m target \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39mor\u001b[39;00m \u001b[39mnot\u001b[39;00m target_has_ref_type\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:475\u001b[0m, in \u001b[0;36mDictConfig._get_node\u001b[0;34m(self, key, validate_access, validate_key, throw_on_missing_value, throw_on_missing_key)\u001b[0m\n\u001b[1;32m    472\u001b[0m             \u001b[39mreturn\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    474\u001b[0m \u001b[39mif\u001b[39;00m validate_access:\n\u001b[0;32m--> 475\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_get(key)\n\u001b[1;32m    477\u001b[0m value: Optional[Node] \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m[\u001b[39m\"\u001b[39m\u001b[39m_content\u001b[39m\u001b[39m\"\u001b[39m]\u001b[39m.\u001b[39mget(key)\n\u001b[1;32m    478\u001b[0m \u001b[39mif\u001b[39;00m value \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:164\u001b[0m, in \u001b[0;36mDictConfig._validate_get\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    162\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    163\u001b[0m     msg \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mKey \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mkey\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m is not in struct\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 164\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    165\u001b[0m     key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, cause\u001b[39m=\u001b[39;49mConfigAttributeError(msg)\n\u001b[1;32m    166\u001b[0m )\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:899\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    896\u001b[0m     ex\u001b[39m.\u001b[39mref_type \u001b[39m=\u001b[39m ref_type\n\u001b[1;32m    897\u001b[0m     ex\u001b[39m.\u001b[39mref_type_str \u001b[39m=\u001b[39m ref_type_str\n\u001b[0;32m--> 899\u001b[0m _raise(ex, cause)\n",
-      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
-      "\u001b[0;31mConfigCompositionException\u001b[0m: In 'lower_level_class/lower_level_class_4': ConfigKeyError raised while composing config:\nKey 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass"
-     ]
+     "data": {
+      "text/plain": [
+       "TopLevelClass(-9, LowerLevelClass(99))"
+      ]
+     },
+     "execution_count": 81,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -1249,15 +1228,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 82,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/core/default_element.py:122: UserWarning: In 'lower_level_class/lower_level_class_5': Usage of deprecated keyword in package header '# @package _group_'.\n",
-      "See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
+      "/home/ubuntu/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_5': Usage of deprecated keyword in package header '# @package _group_'.\n",
+      "See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
       "  deprecation_warning(\n"
      ]
     },
@@ -1267,7 +1246,7 @@
        "TopLevelClass(-9, LowerLevelClass(123))"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 82,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/ipynb/add_conf_demo.ipynb
+++ b/ipynb/add_conf_demo.ipynb
@@ -2,29 +2,48 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 63,
    "metadata": {},
    "outputs": [
     {
-     "ename": "",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[1;31mRunning cells with 'hydra-zen' requires ipykernel package.\n",
-      "\u001b[1;31mRun the following command to install 'ipykernel' into the Python environment. \n",
-      "\u001b[1;31mCommand: 'conda install -n hydra-zen ipykernel --update-deps --force-reinstall'"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
      ]
     }
    ],
    "source": [
-    "from hydra_zen import add_conf, add_func_conf, ConfMode, _add_conf #,cs, zen_dry_run, launch_and_instantiate\n",
-    "from hydra_zen import launch\n",
+    "#from hydra_zen import add_conf, add_func_conf, ConfMode, _add_conf, cs, zen_dry_run, launch_and_instantiate\n",
+    "from hydra_zen.structured_configs._add_conf import ConfMode, add_conf, ZenExtras, cs\n",
+    "from hydra_zen import launch, instantiate\n",
     "from typing import Any, List\n",
     "from omegaconf import MISSING\n",
     "import pandas as pd\n",
     "%load_ext autoreload \n",
     "%autoreload 2\n",
     "%config Completer.use_jedi = False"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def launch_and_instantiate(cfg):\n",
+    "    \"\"\"It takes a configuration object and returns a class object. Intended to be called by\n",
+    "    hydra_zen.launch.\n",
+    "\n",
+    "    Args:\n",
+    "        cfg: a dictionary of parameters for the model.\n",
+    "\n",
+    "    Returns:\n",
+    "        The instantiated class.\n",
+    "    \"\"\"\n",
+    "    C = instantiate(cfg)\n",
+    "    return C"
    ]
   },
   {
@@ -43,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
     {
@@ -52,7 +71,7 @@
        "MyClass(dog, 3)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -76,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -85,7 +104,7 @@
        "types.Builds_MyClass"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -97,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -106,7 +125,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='dog', b=3, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -119,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
@@ -128,7 +147,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -140,7 +159,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -149,7 +168,7 @@
        "MyClass(dog, 3)"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -161,7 +180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
@@ -170,7 +189,7 @@
        "MyClass(Bloom, 3)"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,7 +201,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -191,7 +210,7 @@
        "Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), _recursive_=False, a='Bloom', b=999, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -219,7 +238,7 @@
        "MyClass(Lily, 3)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -231,7 +250,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -240,7 +259,7 @@
        "MyClass(Lily, 3)"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -252,7 +271,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -261,7 +280,7 @@
        "MyClass(Bloom, 47)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -275,7 +294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -284,7 +303,7 @@
        "MyClass(Bloom, 117)"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -294,6 +313,26 @@
     "my_class = MyClass(a='Lily', b=117)\n",
     "my_class_bloom = my_class.conf(a=\"Bloom\")\n",
     "my_class_bloom.instantiate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 42,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "issubclass(MyClass.Conf,ZenExtras)"
    ]
   },
   {
@@ -546,7 +585,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 67,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +618,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 68,
    "metadata": {},
    "outputs": [
     {
@@ -588,7 +627,7 @@
        "LowerLevelClass(hello)"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 68,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -603,16 +642,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 69,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['_dummy_empty_config_.yaml', 'hydra', 'lower_level_class_1.yaml']"
+       "['_dummy_empty_config_.yaml',\n",
+       " 'hydra',\n",
+       " 'llc_group',\n",
+       " 'lower_level_class',\n",
+       " 'lower_level_class_1.yaml',\n",
+       " 'lower_level_class_2.yaml',\n",
+       " 'mlc_group',\n",
+       " 'top_level_class.yaml',\n",
+       " 'top_level_class_2.yaml',\n",
+       " 'zen_launch.yaml']"
       ]
      },
-     "execution_count": 25,
+     "execution_count": 69,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -624,7 +672,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 70,
    "metadata": {},
    "outputs": [
     {
@@ -633,7 +681,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b=99, name_='lower_level_class_2', group_=None, package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 70,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -648,7 +696,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 71,
    "metadata": {},
    "outputs": [
     {
@@ -656,11 +704,17 @@
       "text/plain": [
        "['_dummy_empty_config_.yaml',\n",
        " 'hydra',\n",
+       " 'llc_group',\n",
+       " 'lower_level_class',\n",
        " 'lower_level_class_1.yaml',\n",
-       " 'lower_level_class_2.yaml']"
+       " 'lower_level_class_2.yaml',\n",
+       " 'mlc_group',\n",
+       " 'top_level_class.yaml',\n",
+       " 'top_level_class_2.yaml',\n",
+       " 'zen_launch.yaml']"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 71,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -671,7 +725,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 72,
    "metadata": {},
    "outputs": [
     {
@@ -680,7 +734,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b=99, name_='lower_level_class_4', group_='lower_level_class', package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 72,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -701,7 +755,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [
     {
@@ -710,7 +764,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), b='hello', name_='lower_level_class_3', group_='lower_level_class', package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 55,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -724,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -737,33 +791,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 77,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py:235: UserWarning: \n",
-      "The version_base parameter is not specified.\n",
-      "Please specify a compatability version level, or None.\n",
-      "Will assume defaults for version 1.1\n",
-      "  with initialize(\n",
-      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_3': Usage of deprecated keyword in package header '# @package _group_'.\n",
-      "See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
-      "  deprecation_warning(\n",
-      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py:265: UserWarning: Future Hydra versions will no longer change working directory at job runtime by default.\n",
-      "See https://hydra.cc/docs/next/upgrades/1.1_to_1.2/changes_to_job_working_dir/ for more information.\n",
-      "  job = run_job(\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "TopLevelClass(0, LowerLevelClass(hello))"
       ]
      },
-     "execution_count": 31,
+     "execution_count": 77,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -775,30 +812,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 78,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra_zen/_launch.py:235: UserWarning: \n",
-      "The version_base parameter is not specified.\n",
-      "Please specify a compatability version level, or None.\n",
-      "Will assume defaults for version 1.1\n",
-      "  with initialize(\n",
-      "/home/ubuntu/anaconda3/envs/orange/lib/python3.9/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_4': Usage of deprecated keyword in package header '# @package _group_'.\n",
-      "See https://hydra.cc/docs/next/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
-      "  deprecation_warning(\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "TopLevelClass(0, LowerLevelClass(99))"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 78,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -820,7 +843,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -866,7 +889,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 59,
    "metadata": {},
    "outputs": [
     {
@@ -875,7 +898,7 @@
        "Builds_LowerLevelClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.LowerLevelClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), c='type 1', name_='llc_1', group_='llc_group', package_='_group_', provider_=None, defaults=['_self_'])"
       ]
      },
-     "execution_count": 34,
+     "execution_count": 59,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -906,25 +929,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 60,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "_zen_target: __main__.MidLevelClass\n",
-      "b: 1\n",
-      "lower_level_class:\n",
-      "  _zen_target: __main__.LowerLevelClass\n",
-      "  c: type 3\n",
-      "  name_: llc_3\n",
-      "  group_: llc_group\n",
-      "name_: mlc_1\n",
-      "group_: mlc_group\n",
-      "defaults:\n",
-      "- /llc_group@lower_level_class: llc_3\n",
-      "\n"
+     "ename": "NameError",
+     "evalue": "name 'delete_keys_from_dict' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[60], line 28\u001b[0m\n\u001b[1;32m     16\u001b[0m mlc_3 \u001b[39m=\u001b[39m MidLevelClass\u001b[39m.\u001b[39mConf(\n\u001b[1;32m     17\u001b[0m     b \u001b[39m=\u001b[39m \u001b[39m3\u001b[39m,\n\u001b[1;32m     18\u001b[0m     lower_level_class\u001b[39m=\u001b[39mMISSING,\n\u001b[1;32m     19\u001b[0m     name_\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mmlc_3\u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     20\u001b[0m )\n\u001b[1;32m     22\u001b[0m mlc_4 \u001b[39m=\u001b[39m MidLevelClass\u001b[39m.\u001b[39mConf(\n\u001b[1;32m     23\u001b[0m     b \u001b[39m=\u001b[39m \u001b[39m4\u001b[39m,\n\u001b[1;32m     24\u001b[0m     lower_level_class\u001b[39m=\u001b[39mllc_4,\n\u001b[1;32m     25\u001b[0m     name_\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mmlc_4\u001b[39m\u001b[39m'\u001b[39m\n\u001b[1;32m     26\u001b[0m )\n\u001b[0;32m---> 28\u001b[0m mlc_1\u001b[39m.\u001b[39;49mshow()\n",
+      "File \u001b[0;32m~/loyal/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:445\u001b[0m, in \u001b[0;36mZenExtras.show\u001b[0;34m(self, verbosity, exclude_keys, *args, **kwargs)\u001b[0m\n\u001b[1;32m    443\u001b[0m \u001b[39melif\u001b[39;00m verbosity \u001b[39m==\u001b[39m \u001b[39m\"\u001b[39m\u001b[39mcompact\u001b[39m\u001b[39m\"\u001b[39m:\n\u001b[1;32m    444\u001b[0m     d \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mto_dict()\n\u001b[0;32m--> 445\u001b[0m     delete_keys_from_dict(d, exclude_keys)\n\u001b[1;32m    446\u001b[0m     delete_null_cs_keys(d)\n\u001b[1;32m    447\u001b[0m     delete_null_vals_from_dict(d)\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'delete_keys_from_dict' is not defined"
      ]
     }
    ],
@@ -1108,9 +1125,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 79,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Builds_LowerLevelClass.__init__() got an unexpected keyword argument 'c'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[79], line 2\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[39mwith\u001b[39;00m ConfMode():\n\u001b[0;32m----> 2\u001b[0m     LowerLevelClass(\n\u001b[1;32m      3\u001b[0m         name_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class_5\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      4\u001b[0m         group_\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class\u001b[39;49m\u001b[39m'\u001b[39;49m,\n\u001b[1;32m      5\u001b[0m         c\u001b[39m=\u001b[39;49m\u001b[39m117\u001b[39;49m,\n\u001b[1;32m      6\u001b[0m     )\n\u001b[1;32m      7\u001b[0m     top_level_class_config_2 \u001b[39m=\u001b[39m TopLevelClass(\n\u001b[1;32m      8\u001b[0m         a\u001b[39m=\u001b[39m\u001b[39m-\u001b[39m\u001b[39m9\u001b[39m,\n\u001b[1;32m      9\u001b[0m         name_\u001b[39m=\u001b[39m\u001b[39m'\u001b[39m\u001b[39mtop_level_class_2\u001b[39m\u001b[39m'\u001b[39m, \n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m     12\u001b[0m             {\u001b[39m'\u001b[39m\u001b[39mlower_level_class\u001b[39m\u001b[39m'\u001b[39m: \u001b[39m'\u001b[39m\u001b[39mlower_level_class_5\u001b[39m\u001b[39m'\u001b[39m}]\n\u001b[1;32m     13\u001b[0m     )\n",
+      "File \u001b[0;32m~/loyal/hydra-zen/src/hydra_zen/structured_configs/_add_conf.py:205\u001b[0m, in \u001b[0;36moverride_constructor.<locals>.WrappedClass.__new__\u001b[0;34m(cls, name_, group_, package_, provider_, defaults, *args, **kwargs)\u001b[0m\n\u001b[1;32m    203\u001b[0m \u001b[39mglobal\u001b[39;00m _configuring\n\u001b[1;32m    204\u001b[0m \u001b[39mif\u001b[39;00m _configuring:\n\u001b[0;32m--> 205\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mcls\u001b[39;49m\u001b[39m.\u001b[39;49mConf(\u001b[39m*\u001b[39;49margs, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mzen_meta, \u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkwargs)\n\u001b[1;32m    206\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    207\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39msuper\u001b[39m(WrappedClass, \u001b[39mcls\u001b[39m)\u001b[39m.\u001b[39m\u001b[39m__new__\u001b[39m(\u001b[39mcls\u001b[39m)\n",
+      "\u001b[0;31mTypeError\u001b[0m: Builds_LowerLevelClass.__init__() got an unexpected keyword argument 'c'"
+     ]
+    }
+   ],
    "source": [
     "with ConfMode():\n",
     "    LowerLevelClass(\n",
@@ -1129,18 +1159,83 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 66,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/plain": [
-       "TopLevelClass(-9, LowerLevelClass(99))"
-      ]
-     },
-     "execution_count": 38,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/ubuntu/loyal/hydra-zen/src/hydra_zen/_launch.py:236: UserWarning: \n",
+      "The version_base parameter is not specified.\n",
+      "Please specify a compatability version level, or None.\n",
+      "Will assume defaults for version 1.1\n",
+      "  with initialize(\n",
+      "/home/ubuntu/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/core/default_element.py:124: UserWarning: In 'lower_level_class/lower_level_class_4': Usage of deprecated keyword in package header '# @package _group_'.\n",
+      "See https://hydra.cc/docs/1.2/upgrades/1.0_to_1.1/changes_to_package_header for more information\n",
+      "  deprecation_warning(\n"
+     ]
+    },
+    {
+     "ename": "ConfigCompositionException",
+     "evalue": "In 'lower_level_class/lower_level_class_4': ConfigKeyError raised while composing config:\nKey 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mConfigKeyError\u001b[0m                            Traceback (most recent call last)",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:542\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    541\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 542\u001b[0m     cfg\u001b[39m.\u001b[39;49mmerge_with(loaded\u001b[39m.\u001b[39;49mconfig)\n\u001b[1;32m    543\u001b[0m \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:492\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 492\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(key\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, value\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, cause\u001b[39m=\u001b[39;49me)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:490\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    489\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 490\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_merge_with(\u001b[39m*\u001b[39;49mothers)\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:514\u001b[0m, in \u001b[0;36mBaseContainer._merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    513\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, DictConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, DictConfig):\n\u001b[0;32m--> 514\u001b[0m     BaseContainer\u001b[39m.\u001b[39;49m_map_merge(\u001b[39mself\u001b[39;49m, other)\n\u001b[1;32m    515\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, ListConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, ListConfig):\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:432\u001b[0m, in \u001b[0;36mBaseContainer._map_merge\u001b[0;34m(dest, src)\u001b[0m\n\u001b[1;32m    431\u001b[0m         \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 432\u001b[0m             dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    434\u001b[0m _update_types(node\u001b[39m=\u001b[39mdest, ref_type\u001b[39m=\u001b[39msrc_ref_type, object_type\u001b[39m=\u001b[39msrc_type)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:310\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 310\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    311\u001b[0m         key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, type_override\u001b[39m=\u001b[39;49mConfigKeyError, cause\u001b[39m=\u001b[39;49me\n\u001b[1;32m    312\u001b[0m     )\n\u001b[1;32m    313\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:308\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    307\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 308\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m__set_impl(key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue)\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:318\u001b[0m, in \u001b[0;36mDictConfig.__set_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    317\u001b[0m key \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_and_normalize_key(key)\n\u001b[0;32m--> 318\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_set_item_impl(key, value)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:545\u001b[0m, in \u001b[0;36mBaseContainer._set_item_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    544\u001b[0m     value\u001b[39m.\u001b[39m_set_key(key)\n\u001b[0;32m--> 545\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_set(key, value)\n\u001b[1;32m    546\u001b[0m \u001b[39mfinally\u001b[39;00m:\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:180\u001b[0m, in \u001b[0;36mDictConfig._validate_set\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    178\u001b[0m     \u001b[39mreturn\u001b[39;00m\n\u001b[0;32m--> 180\u001b[0m target \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_node(key) \u001b[39mif\u001b[39;00m key \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39melse\u001b[39;00m \u001b[39mself\u001b[39m\n\u001b[1;32m    182\u001b[0m target_has_ref_type \u001b[39m=\u001b[39m \u001b[39misinstance\u001b[39m(\n\u001b[1;32m    183\u001b[0m     target, DictConfig\n\u001b[1;32m    184\u001b[0m ) \u001b[39mand\u001b[39;00m target\u001b[39m.\u001b[39m_metadata\u001b[39m.\u001b[39mref_type \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m (Any, \u001b[39mdict\u001b[39m)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:475\u001b[0m, in \u001b[0;36mDictConfig._get_node\u001b[0;34m(self, key, validate_access, validate_key, throw_on_missing_value, throw_on_missing_key)\u001b[0m\n\u001b[1;32m    474\u001b[0m \u001b[39mif\u001b[39;00m validate_access:\n\u001b[0;32m--> 475\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_get(key)\n\u001b[1;32m    477\u001b[0m value: Optional[Node] \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m[\u001b[39m\"\u001b[39m\u001b[39m_content\u001b[39m\u001b[39m\"\u001b[39m]\u001b[39m.\u001b[39mget(key)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:164\u001b[0m, in \u001b[0;36mDictConfig._validate_get\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    163\u001b[0m     msg \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mKey \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mkey\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m is not in struct\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 164\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    165\u001b[0m     key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, cause\u001b[39m=\u001b[39;49mConfigAttributeError(msg)\n\u001b[1;32m    166\u001b[0m )\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:899\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    897\u001b[0m     ex\u001b[39m.\u001b[39mref_type_str \u001b[39m=\u001b[39m ref_type_str\n\u001b[0;32m--> 899\u001b[0m _raise(ex, cause)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "\u001b[0;31mConfigKeyError\u001b[0m: Key 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mConfigCompositionException\u001b[0m                Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[66], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m out \u001b[39m=\u001b[39m launch(\n\u001b[1;32m      2\u001b[0m     top_level_class_config_2, \n\u001b[1;32m      3\u001b[0m     launch_and_instantiate, \n\u001b[1;32m      4\u001b[0m     overrides\u001b[39m=\u001b[39;49m[\u001b[39m'\u001b[39;49m\u001b[39mlower_level_class=lower_level_class_4\u001b[39;49m\u001b[39m'\u001b[39;49m]\n\u001b[1;32m      5\u001b[0m     )\n\u001b[1;32m      6\u001b[0m out\u001b[39m.\u001b[39mreturn_value\n",
+      "File \u001b[0;32m~/loyal/hydra-zen/src/hydra_zen/_launch.py:251\u001b[0m, in \u001b[0;36mlaunch\u001b[0;34m(config, task_function, overrides, multirun, version_base, to_dictconfig, config_name, job_name, with_log_configuration)\u001b[0m\n\u001b[1;32m    248\u001b[0m \u001b[39massert\u001b[39;00m gh\u001b[39m.\u001b[39mhydra \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    250\u001b[0m \u001b[39m# Load configuration\u001b[39;00m\n\u001b[0;32m--> 251\u001b[0m cfg \u001b[39m=\u001b[39m gh\u001b[39m.\u001b[39;49mhydra\u001b[39m.\u001b[39;49mcompose_config(\n\u001b[1;32m    252\u001b[0m     config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    253\u001b[0m     overrides\u001b[39m=\u001b[39;49moverrides \u001b[39mif\u001b[39;49;00m overrides \u001b[39mis\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m [],\n\u001b[1;32m    254\u001b[0m     run_mode\u001b[39m=\u001b[39;49mRunMode\u001b[39m.\u001b[39;49mRUN \u001b[39mif\u001b[39;49;00m \u001b[39mnot\u001b[39;49;00m multirun \u001b[39melse\u001b[39;49;00m RunMode\u001b[39m.\u001b[39;49mMULTIRUN,\n\u001b[1;32m    255\u001b[0m     from_shell\u001b[39m=\u001b[39;49m\u001b[39mFalse\u001b[39;49;00m,\n\u001b[1;32m    256\u001b[0m     with_log_configuration\u001b[39m=\u001b[39;49mwith_log_configuration,\n\u001b[1;32m    257\u001b[0m )\n\u001b[1;32m    259\u001b[0m callbacks \u001b[39m=\u001b[39m Callbacks(cfg)\n\u001b[1;32m    260\u001b[0m run_start \u001b[39m=\u001b[39m (\n\u001b[1;32m    261\u001b[0m     callbacks\u001b[39m.\u001b[39mon_run_start \u001b[39mif\u001b[39;00m \u001b[39mnot\u001b[39;00m multirun \u001b[39melse\u001b[39;00m callbacks\u001b[39m.\u001b[39mon_multirun_start\n\u001b[1;32m    262\u001b[0m )\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/hydra.py:594\u001b[0m, in \u001b[0;36mHydra.compose_config\u001b[0;34m(self, config_name, overrides, run_mode, with_log_configuration, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    576\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mcompose_config\u001b[39m(\n\u001b[1;32m    577\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    578\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    583\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    584\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    585\u001b[0m \u001b[39m    \u001b[39m\u001b[39m\"\"\"\u001b[39;00m\n\u001b[1;32m    586\u001b[0m \u001b[39m    :param config_name:\u001b[39;00m\n\u001b[1;32m    587\u001b[0m \u001b[39m    :param overrides:\u001b[39;00m\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    591\u001b[0m \u001b[39m    :return:\u001b[39;00m\n\u001b[1;32m    592\u001b[0m \u001b[39m    \"\"\"\u001b[39;00m\n\u001b[0;32m--> 594\u001b[0m     cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconfig_loader\u001b[39m.\u001b[39;49mload_configuration(\n\u001b[1;32m    595\u001b[0m         config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    596\u001b[0m         overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    597\u001b[0m         run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    598\u001b[0m         from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    599\u001b[0m         validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    600\u001b[0m     )\n\u001b[1;32m    601\u001b[0m     \u001b[39mif\u001b[39;00m with_log_configuration:\n\u001b[1;32m    602\u001b[0m         configure_log(cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mhydra_logging, cfg\u001b[39m.\u001b[39mhydra\u001b[39m.\u001b[39mverbose)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:142\u001b[0m, in \u001b[0;36mConfigLoaderImpl.load_configuration\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    133\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mload_configuration\u001b[39m(\n\u001b[1;32m    134\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    135\u001b[0m     config_name: Optional[\u001b[39mstr\u001b[39m],\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    139\u001b[0m     validate_sweep_overrides: \u001b[39mbool\u001b[39m \u001b[39m=\u001b[39m \u001b[39mTrue\u001b[39;00m,\n\u001b[1;32m    140\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m DictConfig:\n\u001b[1;32m    141\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 142\u001b[0m         \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_load_configuration_impl(\n\u001b[1;32m    143\u001b[0m             config_name\u001b[39m=\u001b[39;49mconfig_name,\n\u001b[1;32m    144\u001b[0m             overrides\u001b[39m=\u001b[39;49moverrides,\n\u001b[1;32m    145\u001b[0m             run_mode\u001b[39m=\u001b[39;49mrun_mode,\n\u001b[1;32m    146\u001b[0m             from_shell\u001b[39m=\u001b[39;49mfrom_shell,\n\u001b[1;32m    147\u001b[0m             validate_sweep_overrides\u001b[39m=\u001b[39;49mvalidate_sweep_overrides,\n\u001b[1;32m    148\u001b[0m         )\n\u001b[1;32m    149\u001b[0m     \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    150\u001b[0m         \u001b[39mraise\u001b[39;00m ConfigCompositionException()\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m]) \u001b[39mfrom\u001b[39;00m \u001b[39me\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:263\u001b[0m, in \u001b[0;36mConfigLoaderImpl._load_configuration_impl\u001b[0;34m(self, config_name, overrides, run_mode, from_shell, validate_sweep_overrides)\u001b[0m\n\u001b[1;32m    253\u001b[0m defaults_list \u001b[39m=\u001b[39m create_defaults_list(\n\u001b[1;32m    254\u001b[0m     repo\u001b[39m=\u001b[39mcaching_repo,\n\u001b[1;32m    255\u001b[0m     config_name\u001b[39m=\u001b[39mconfig_name,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    258\u001b[0m     skip_missing\u001b[39m=\u001b[39mrun_mode \u001b[39m==\u001b[39m RunMode\u001b[39m.\u001b[39mMULTIRUN,\n\u001b[1;32m    259\u001b[0m )\n\u001b[1;32m    261\u001b[0m config_overrides \u001b[39m=\u001b[39m defaults_list\u001b[39m.\u001b[39mconfig_overrides\n\u001b[0;32m--> 263\u001b[0m cfg \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_compose_config_from_defaults_list(\n\u001b[1;32m    264\u001b[0m     defaults\u001b[39m=\u001b[39;49mdefaults_list\u001b[39m.\u001b[39;49mdefaults, repo\u001b[39m=\u001b[39;49mcaching_repo\n\u001b[1;32m    265\u001b[0m )\n\u001b[1;32m    267\u001b[0m \u001b[39m# Set config root to struct mode.\u001b[39;00m\n\u001b[1;32m    268\u001b[0m \u001b[39m# Note that this will close any dictionaries (including dicts annotated as Dict[K, V].\u001b[39;00m\n\u001b[1;32m    269\u001b[0m \u001b[39m# One must use + to add new fields to them.\u001b[39;00m\n\u001b[1;32m    270\u001b[0m OmegaConf\u001b[39m.\u001b[39mset_struct(cfg, \u001b[39mTrue\u001b[39;00m)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:544\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    542\u001b[0m             cfg\u001b[39m.\u001b[39mmerge_with(loaded\u001b[39m.\u001b[39mconfig)\n\u001b[1;32m    543\u001b[0m         \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 544\u001b[0m             \u001b[39mraise\u001b[39;00m ConfigCompositionException(\n\u001b[1;32m    545\u001b[0m                 \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mIn \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mdefault\u001b[39m.\u001b[39mconfig_path\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m: \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mtype\u001b[39m(e)\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m raised while\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    546\u001b[0m                 \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m composing config:\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00me\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[1;32m    547\u001b[0m             )\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n\u001b[1;32m    549\u001b[0m \u001b[39m# # remove remaining defaults lists from all nodes.\u001b[39;00m\n\u001b[1;32m    550\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mstrip_defaults\u001b[39m(cfg: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/hydra/_internal/config_loader_impl.py:542\u001b[0m, in \u001b[0;36mConfigLoaderImpl._compose_config_from_defaults_list\u001b[0;34m(self, defaults, repo)\u001b[0m\n\u001b[1;32m    540\u001b[0m loaded \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_load_single_config(default\u001b[39m=\u001b[39mdefault, repo\u001b[39m=\u001b[39mrepo)\n\u001b[1;32m    541\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 542\u001b[0m     cfg\u001b[39m.\u001b[39;49mmerge_with(loaded\u001b[39m.\u001b[39;49mconfig)\n\u001b[1;32m    543\u001b[0m \u001b[39mexcept\u001b[39;00m OmegaConfBaseException \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    544\u001b[0m     \u001b[39mraise\u001b[39;00m ConfigCompositionException(\n\u001b[1;32m    545\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mIn \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mdefault\u001b[39m.\u001b[39mconfig_path\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m: \u001b[39m\u001b[39m{\u001b[39;00m\u001b[39mtype\u001b[39m(e)\u001b[39m.\u001b[39m\u001b[39m__name__\u001b[39m\u001b[39m}\u001b[39;00m\u001b[39m raised while\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m    546\u001b[0m         \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m composing config:\u001b[39m\u001b[39m\\n\u001b[39;00m\u001b[39m{\u001b[39;00me\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m\n\u001b[1;32m    547\u001b[0m     )\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:492\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    490\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_merge_with(\u001b[39m*\u001b[39mothers)\n\u001b[1;32m    491\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 492\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(key\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, value\u001b[39m=\u001b[39;49m\u001b[39mNone\u001b[39;49;00m, cause\u001b[39m=\u001b[39;49me)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    817\u001b[0m         ex \u001b[39m=\u001b[39m type_override(\u001b[39mstr\u001b[39m(cause))\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n\u001b[1;32m    822\u001b[0m object_type_str: Optional[\u001b[39mstr\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:490\u001b[0m, in \u001b[0;36mBaseContainer.merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    483\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mmerge_with\u001b[39m(\n\u001b[1;32m    484\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    485\u001b[0m     \u001b[39m*\u001b[39mothers: Union[\n\u001b[1;32m    486\u001b[0m         \u001b[39m\"\u001b[39m\u001b[39mBaseContainer\u001b[39m\u001b[39m\"\u001b[39m, Dict[\u001b[39mstr\u001b[39m, Any], List[Any], Tuple[Any, \u001b[39m.\u001b[39m\u001b[39m.\u001b[39m\u001b[39m.\u001b[39m], Any\n\u001b[1;32m    487\u001b[0m     ],\n\u001b[1;32m    488\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    489\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 490\u001b[0m         \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_merge_with(\u001b[39m*\u001b[39;49mothers)\n\u001b[1;32m    491\u001b[0m     \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    492\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(key\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m, value\u001b[39m=\u001b[39m\u001b[39mNone\u001b[39;00m, cause\u001b[39m=\u001b[39me)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:514\u001b[0m, in \u001b[0;36mBaseContainer._merge_with\u001b[0;34m(self, *others)\u001b[0m\n\u001b[1;32m    511\u001b[0m other \u001b[39m=\u001b[39m _ensure_container(other, flags\u001b[39m=\u001b[39mmy_flags)\n\u001b[1;32m    513\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, DictConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, DictConfig):\n\u001b[0;32m--> 514\u001b[0m     BaseContainer\u001b[39m.\u001b[39;49m_map_merge(\u001b[39mself\u001b[39;49m, other)\n\u001b[1;32m    515\u001b[0m \u001b[39melif\u001b[39;00m \u001b[39misinstance\u001b[39m(\u001b[39mself\u001b[39m, ListConfig) \u001b[39mand\u001b[39;00m \u001b[39misinstance\u001b[39m(other, ListConfig):\n\u001b[1;32m    516\u001b[0m     BaseContainer\u001b[39m.\u001b[39m_list_merge(\u001b[39mself\u001b[39m, other)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:432\u001b[0m, in \u001b[0;36mBaseContainer._map_merge\u001b[0;34m(dest, src)\u001b[0m\n\u001b[1;32m    430\u001b[0m                 dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    431\u001b[0m         \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 432\u001b[0m             dest[key] \u001b[39m=\u001b[39m src\u001b[39m.\u001b[39m_get_node(key)\n\u001b[1;32m    434\u001b[0m _update_types(node\u001b[39m=\u001b[39mdest, ref_type\u001b[39m=\u001b[39msrc_ref_type, object_type\u001b[39m=\u001b[39msrc_type)\n\u001b[1;32m    436\u001b[0m \u001b[39m# explicit flags on the source config are replacing the flag values in the destination\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:310\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    308\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m__set_impl(key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue)\n\u001b[1;32m    309\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[0;32m--> 310\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    311\u001b[0m         key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, type_override\u001b[39m=\u001b[39;49mConfigKeyError, cause\u001b[39m=\u001b[39;49me\n\u001b[1;32m    312\u001b[0m     )\n\u001b[1;32m    313\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mException\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    314\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue, cause\u001b[39m=\u001b[39me)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:819\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    817\u001b[0m         ex \u001b[39m=\u001b[39m type_override(\u001b[39mstr\u001b[39m(cause))\n\u001b[1;32m    818\u001b[0m         ex\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m \u001b[39m=\u001b[39m copy\u001b[39m.\u001b[39mdeepcopy(cause\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m)\n\u001b[0;32m--> 819\u001b[0m     _raise(ex, cause)\n\u001b[1;32m    821\u001b[0m object_type: Optional[Type[Any]]\n\u001b[1;32m    822\u001b[0m object_type_str: Optional[\u001b[39mstr\u001b[39m] \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:308\u001b[0m, in \u001b[0;36mDictConfig.__setitem__\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    306\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__setitem__\u001b[39m(\u001b[39mself\u001b[39m, key: DictKeyType, value: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    307\u001b[0m     \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 308\u001b[0m         \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m__set_impl(key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue)\n\u001b[1;32m    309\u001b[0m     \u001b[39mexcept\u001b[39;00m \u001b[39mAttributeError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n\u001b[1;32m    310\u001b[0m         \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_format_and_raise(\n\u001b[1;32m    311\u001b[0m             key\u001b[39m=\u001b[39mkey, value\u001b[39m=\u001b[39mvalue, type_override\u001b[39m=\u001b[39mConfigKeyError, cause\u001b[39m=\u001b[39me\n\u001b[1;32m    312\u001b[0m         )\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:318\u001b[0m, in \u001b[0;36mDictConfig.__set_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    316\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m__set_impl\u001b[39m(\u001b[39mself\u001b[39m, key: DictKeyType, value: Any) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    317\u001b[0m     key \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_validate_and_normalize_key(key)\n\u001b[0;32m--> 318\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_set_item_impl(key, value)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/basecontainer.py:545\u001b[0m, in \u001b[0;36mBaseContainer._set_item_impl\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    543\u001b[0m     old \u001b[39m=\u001b[39m value\u001b[39m.\u001b[39m_key()\n\u001b[1;32m    544\u001b[0m     value\u001b[39m.\u001b[39m_set_key(key)\n\u001b[0;32m--> 545\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_set(key, value)\n\u001b[1;32m    546\u001b[0m \u001b[39mfinally\u001b[39;00m:\n\u001b[1;32m    547\u001b[0m     value\u001b[39m.\u001b[39m_set_key(old)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:180\u001b[0m, in \u001b[0;36mDictConfig._validate_set\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    177\u001b[0m \u001b[39mif\u001b[39;00m vk \u001b[39m==\u001b[39m ValueKind\u001b[39m.\u001b[39mMANDATORY_MISSING \u001b[39mor\u001b[39;00m value \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n\u001b[1;32m    178\u001b[0m     \u001b[39mreturn\u001b[39;00m\n\u001b[0;32m--> 180\u001b[0m target \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_get_node(key) \u001b[39mif\u001b[39;00m key \u001b[39mis\u001b[39;00m \u001b[39mnot\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39melse\u001b[39;00m \u001b[39mself\u001b[39m\n\u001b[1;32m    182\u001b[0m target_has_ref_type \u001b[39m=\u001b[39m \u001b[39misinstance\u001b[39m(\n\u001b[1;32m    183\u001b[0m     target, DictConfig\n\u001b[1;32m    184\u001b[0m ) \u001b[39mand\u001b[39;00m target\u001b[39m.\u001b[39m_metadata\u001b[39m.\u001b[39mref_type \u001b[39mnot\u001b[39;00m \u001b[39min\u001b[39;00m (Any, \u001b[39mdict\u001b[39m)\n\u001b[1;32m    185\u001b[0m is_valid_target \u001b[39m=\u001b[39m target \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m \u001b[39mor\u001b[39;00m \u001b[39mnot\u001b[39;00m target_has_ref_type\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:475\u001b[0m, in \u001b[0;36mDictConfig._get_node\u001b[0;34m(self, key, validate_access, validate_key, throw_on_missing_value, throw_on_missing_key)\u001b[0m\n\u001b[1;32m    472\u001b[0m             \u001b[39mreturn\u001b[39;00m \u001b[39mNone\u001b[39;00m\n\u001b[1;32m    474\u001b[0m \u001b[39mif\u001b[39;00m validate_access:\n\u001b[0;32m--> 475\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_validate_get(key)\n\u001b[1;32m    477\u001b[0m value: Optional[Node] \u001b[39m=\u001b[39m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m\u001b[39m__dict__\u001b[39m[\u001b[39m\"\u001b[39m\u001b[39m_content\u001b[39m\u001b[39m\"\u001b[39m]\u001b[39m.\u001b[39mget(key)\n\u001b[1;32m    478\u001b[0m \u001b[39mif\u001b[39;00m value \u001b[39mis\u001b[39;00m \u001b[39mNone\u001b[39;00m:\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/dictconfig.py:164\u001b[0m, in \u001b[0;36mDictConfig._validate_get\u001b[0;34m(self, key, value)\u001b[0m\n\u001b[1;32m    162\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    163\u001b[0m     msg \u001b[39m=\u001b[39m \u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mKey \u001b[39m\u001b[39m'\u001b[39m\u001b[39m{\u001b[39;00mkey\u001b[39m}\u001b[39;00m\u001b[39m'\u001b[39m\u001b[39m is not in struct\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m--> 164\u001b[0m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_format_and_raise(\n\u001b[1;32m    165\u001b[0m     key\u001b[39m=\u001b[39;49mkey, value\u001b[39m=\u001b[39;49mvalue, cause\u001b[39m=\u001b[39;49mConfigAttributeError(msg)\n\u001b[1;32m    166\u001b[0m )\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/base.py:231\u001b[0m, in \u001b[0;36mNode._format_and_raise\u001b[0;34m(self, key, value, cause, msg, type_override)\u001b[0m\n\u001b[1;32m    223\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_format_and_raise\u001b[39m(\n\u001b[1;32m    224\u001b[0m     \u001b[39mself\u001b[39m,\n\u001b[1;32m    225\u001b[0m     key: Any,\n\u001b[0;32m   (...)\u001b[0m\n\u001b[1;32m    229\u001b[0m     type_override: Any \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m,\n\u001b[1;32m    230\u001b[0m ) \u001b[39m-\u001b[39m\u001b[39m>\u001b[39m \u001b[39mNone\u001b[39;00m:\n\u001b[0;32m--> 231\u001b[0m     format_and_raise(\n\u001b[1;32m    232\u001b[0m         node\u001b[39m=\u001b[39;49m\u001b[39mself\u001b[39;49m,\n\u001b[1;32m    233\u001b[0m         key\u001b[39m=\u001b[39;49mkey,\n\u001b[1;32m    234\u001b[0m         value\u001b[39m=\u001b[39;49mvalue,\n\u001b[1;32m    235\u001b[0m         msg\u001b[39m=\u001b[39;49m\u001b[39mstr\u001b[39;49m(cause) \u001b[39mif\u001b[39;49;00m msg \u001b[39mis\u001b[39;49;00m \u001b[39mNone\u001b[39;49;00m \u001b[39melse\u001b[39;49;00m msg,\n\u001b[1;32m    236\u001b[0m         cause\u001b[39m=\u001b[39;49mcause,\n\u001b[1;32m    237\u001b[0m         type_override\u001b[39m=\u001b[39;49mtype_override,\n\u001b[1;32m    238\u001b[0m     )\n\u001b[1;32m    239\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mFalse\u001b[39;00m\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:899\u001b[0m, in \u001b[0;36mformat_and_raise\u001b[0;34m(node, key, value, msg, cause, type_override)\u001b[0m\n\u001b[1;32m    896\u001b[0m     ex\u001b[39m.\u001b[39mref_type \u001b[39m=\u001b[39m ref_type\n\u001b[1;32m    897\u001b[0m     ex\u001b[39m.\u001b[39mref_type_str \u001b[39m=\u001b[39m ref_type_str\n\u001b[0;32m--> 899\u001b[0m _raise(ex, cause)\n",
+      "File \u001b[0;32m~/anaconda3/envs/hydra-zen/lib/python3.10/site-packages/omegaconf/_utils.py:797\u001b[0m, in \u001b[0;36m_raise\u001b[0;34m(ex, cause)\u001b[0m\n\u001b[1;32m    795\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m    796\u001b[0m     ex\u001b[39m.\u001b[39m__cause__ \u001b[39m=\u001b[39m \u001b[39mNone\u001b[39;00m\n\u001b[0;32m--> 797\u001b[0m \u001b[39mraise\u001b[39;00m ex\u001b[39m.\u001b[39mwith_traceback(sys\u001b[39m.\u001b[39mexc_info()[\u001b[39m2\u001b[39m])\n",
+      "\u001b[0;31mConfigCompositionException\u001b[0m: In 'lower_level_class/lower_level_class_4': ConfigKeyError raised while composing config:\nKey 'lower_level_class' not in 'Builds_TopLevelClass'\n    full_key: lower_level_class\n    object_type=Builds_TopLevelClass"
+     ]
     }
    ],
    "source": [
@@ -1831,7 +1926,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:26:04) [GCC 10.4.0]"
+   "version": "3.10.8"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/ipynb/add_conf_demo.ipynb
+++ b/ipynb/add_conf_demo.ipynb
@@ -2,21 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ubuntu/loyal/newtricks/data_sci_utils/data_sci_utils/hydra_zen.py:292: HydraZenDeprecationWarning: Specifying `make_custom_builds_fn(builds_bases=<...>)` is deprecated as of hydra-zen 0.7.0. It will be an error in hydra-zen 0.8.0. \n",
-      "`builds_bases` must be specified via `builds` manually.\n",
-      "  configures = make_custom_builds_fn(\n"
+     "ename": "",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31mRunning cells with 'hydra-zen' requires ipykernel package.\n",
+      "\u001b[1;31mRun the following command to install 'ipykernel' into the Python environment. \n",
+      "\u001b[1;31mCommand: 'conda install -n hydra-zen ipykernel --update-deps --force-reinstall'"
      ]
     }
    ],
    "source": [
-    "from data_sci_utils.hydra_zen import add_conf, cs, zen_dry_run, launch_and_instantiate, add_func_conf, ConfMode, _add_conf\n",
+    "from hydra_zen import add_conf, add_func_conf, ConfMode, _add_conf #,cs, zen_dry_run, launch_and_instantiate\n",
     "from hydra_zen import launch\n",
     "from typing import Any, List\n",
     "from omegaconf import MISSING\n",
@@ -1815,11 +1816,8 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "0da9c4590e589478921e261661d76c6c7ab7b3f3af4a42bc07d53b3af401017b"
-  },
   "kernelspec": {
-   "display_name": "Python 3.9.10 ('orange')",
+   "display_name": "hydra-zen",
    "language": "python",
    "name": "python3"
   },
@@ -1833,9 +1831,14 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:26:04) [GCC 10.4.0]"
   },
-  "orig_nbformat": 4
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "08e26d46b7b4f1fdfcdd4d684abaf70b6007d139442080e1d602d0a21496e18e"
+   }
+  }
  },
  "nbformat": 4,
  "nbformat_minor": 2

--- a/src/hydra_zen/structured_configs/_add_conf.py
+++ b/src/hydra_zen/structured_configs/_add_conf.py
@@ -1,32 +1,30 @@
-import dataclasses
 import functools
 import inspect
-import warnings
 from collections.abc import MutableMapping
 from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass
-from inspect import isclass, isfunction
+
+# from inspect import isclass, isfunction
 from pathlib import Path
-from pprint import pprint
-from pydoc import locate
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type
+from typing import Optional  # Any,; Callable,; Dict,; List,; Mapping,; Tuple,; Type
 
 from hydra.core.config_store import ConfigStore
-from omegaconf import MISSING, OmegaConf
-from typing_extensions import Literal
+from omegaconf import OmegaConf  # MISSING,
 
-from hydra_zen import (
-    builds,
+from hydra_zen import (  # builds,; make_config,
     instantiate,
     load_from_yaml,
-    make_config,
     make_custom_builds_fn,
     save_as_yaml,
     to_yaml,
 )
-from hydra_zen.typing import SupportedPrimitive, ZenWrappers
-from hydra_zen.typing._implementations import DataClass_
+
+# from typing_extensions import Literal
+
+
+# from hydra_zen.typing import SupportedPrimitive, ZenWrappers
+# from hydra_zen.typing._implementations import DataClass_
 
 # commenting these out for now since builds_bases is deprecated starting from hydra-zen 0.8
 # unclear if we need the functionality we were using it for
@@ -475,6 +473,50 @@ class ZenExtras:
 
         try:
             new_instance.store()
-        except:
+        except Exception:
             pass
         return new_instance
+
+
+def delete_keys_from_dict(dictionary, keys):
+    for key in keys:
+        with suppress(KeyError):
+            del dictionary[key]
+    for value in dictionary.values():
+        if isinstance(value, MutableMapping):
+            delete_keys_from_dict(value, keys)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, MutableMapping):
+                    delete_keys_from_dict(item, keys)
+
+
+def delete_null_cs_keys(dictionary):
+
+    with suppress(KeyError):
+        if dictionary["group_"] is None:
+            del dictionary["group_"]
+        if dictionary["name_"] is None:
+            del dictionary["name_"]
+        if dictionary["defaults"] == ["_self_"]:
+            del dictionary["defaults"]
+    for value in dictionary.values():
+        if isinstance(value, MutableMapping):
+            delete_null_cs_keys(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, MutableMapping):
+                    delete_null_cs_keys(item)
+
+
+def delete_null_vals_from_dict(dictionary):
+
+    for key, val in list(dictionary.items()):
+        if val is None:
+            del dictionary[key]
+        if isinstance(val, MutableMapping):
+            delete_null_vals_from_dict(val)
+        elif isinstance(val, list):
+            for item in val:
+                if isinstance(item, MutableMapping):
+                    delete_null_vals_from_dict(item)

--- a/src/hydra_zen/structured_configs/_add_conf.py
+++ b/src/hydra_zen/structured_configs/_add_conf.py
@@ -1,68 +1,75 @@
+import dataclasses
 import functools
 import inspect
+import warnings
 from collections.abc import MutableMapping
 from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass
-
-# from inspect import isclass, isfunction
+from inspect import isclass, isfunction
 from pathlib import Path
-from typing import Optional  # Any,; Callable,; Dict,; List,; Mapping,; Tuple,; Type
+from pprint import pprint
+from pydoc import locate
+from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type
 
-from omegaconf import OmegaConf  # MISSING,
+from hydra.core.config_store import ConfigStore
+from omegaconf import MISSING, OmegaConf
+from typing_extensions import Literal
 
-from hydra_zen import (  # builds,; make_config,
+from hydra_zen import (
+    builds,
     instantiate,
     load_from_yaml,
+    make_config,
     make_custom_builds_fn,
     save_as_yaml,
-    store,
     to_yaml,
 )
+from hydra_zen.typing import SupportedPrimitive, ZenWrappers
+from hydra_zen.typing._implementations import DataClass_
 
-# from typing_extensions import Literal
+# commenting these out for now since builds_bases is deprecated starting from hydra-zen 0.8
+# unclear if we need the functionality we were using it for
+# zen_meta_defaults = get_zen_meta_defaults()
+# configures = make_custom_builds_fn(populate_full_signature=True, builds_bases=(ZenExtras,), zen_meta=zen_meta_defaults)
 
-# from hydra_zen.typing import SupportedPrimitive, ZenWrappers
-# from hydra_zen.typing._implementations import DataClass_
+configures = make_custom_builds_fn(populate_full_signature=True)
 
 
 def add_conf(*args, **kwargs):
-    """
-    Dispatching for decorator. If the user passes in a single positional argument, then we assume it's a class and we call the
-    _add_conf function. Otherwise, we call the _add_custom_conf function
-
-    """
-    # if kwargs or len(pos_args) > 0:
-    #     return _add_custom_conf(*pos_args, **kwargs) # returns a function that goes on to wrap the class
-    # return _add_conf(cls) # returns a wrapped class
-    if (len(kwargs) == 0) and (len(args) == 1):
-        cls = args[0]
-        return _add_conf(cls, **kwargs)
-    else:
+    if kwargs or len(args) != 1:
         return _add_custom_conf(**kwargs)
+    cls = args[0]
+    return _add_conf(cls, **kwargs)
 
 
 def _add_custom_conf(
-    *pos_args,
+    name_: Optional[str] = None,
+    group_: Optional[str] = None,
+    package_: Optional[str] = "_group_",
+    provider_: Optional[str] = None,
+    defaults: Optional[list] = None,
     **kwargs,
 ):
     """Returns add_conf decorator but with different default arguments to be applied to the class
     level conf.
 
     Args:
-        *pos_args: positional arguments to be passed to the class level conf
-        **kwargs: keyword arguments to be passed to the class level conf
+        name_ (Optional[str], optional): _description_. Defaults to None.
+        group_ (Optional[str], optional): _description_. Defaults to None.
+        package_ (Optional[str], optional): _description_. Defaults to "_group_".
+        provider_ (Optional[str], optional): _description_. Defaults to None.
+        defaults (Optional[list], optional): _description_. Defaults to None.
 
     Returns:
-
+        _type_: _description_
     """
-    return functools.partial(_add_conf, *pos_args, **kwargs)
+    zen_meta = merge_zen_meta_defaults(name_, group_, package_, provider_, defaults)
+    return functools.partial(_add_conf, zen_meta=zen_meta, **kwargs)
 
 
 def _add_conf(
     cls,
-    /,
-    *pos_args,
     **kwargs,
 ):
     """Decorator that adds an attribute called `conf` which holds the configuration object for that
@@ -116,63 +123,60 @@ def _add_conf(
         LogisticRegressionConfig = WrappedLogisticRegression.conf
     """
     wrapped_cls = deepcopy(cls)
-    _Conf = configures(wrapped_cls, **kwargs)  # creates conf dataclass for wrapped_cls
-    setattr(wrapped_cls, "Conf", _Conf)  # adds conf dataclass as Conf
-    wrapped_cls = _override_constructor(wrapped_cls)
+    # validate signature of wrapped class
+    check_class_signature_does_not_include_reserved_keywords(wrapped_cls)
+    check_signature_has_defaults_for_all_parameters(wrapped_cls)
+    conf = configures(wrapped_cls, **kwargs)  # creates conf dataclass for wrapped_cls
+    setattr(wrapped_cls, "Conf", conf)  # adds conf dataclass as Conf
+    wrapped_cls = override_constructor(wrapped_cls)
     # wrapped_cls = override_mro(wrapped_cls,mro=cls.__mor__) # let's leave this as a reminder
-    wrapped_cls = make_get_state_ignore_conf(wrapped_cls)  # so that pickling works
+    wrapped_cls = make_get_state_ignore_conf(wrapped_cls)
 
     return wrapped_cls
 
 
-@dataclass
-class Conf:
-    def __call__(self, **kwargs):
-        """`__call__` takes a dictionary of keyword arguments, merges them with the current
-        instance of the class, and returns a new instance of the class with the updated config.
-
-        Returns:
-            A new instance of the class, with the new values set.
-        """
-
-        new_instance = deepcopy(self)
-        for key, value in kwargs.items():
-            setattr(new_instance, key, value)
-
-        return new_instance
-
-
-configures = make_custom_builds_fn(
-    populate_full_signature=True,
-    zen_dataclass={"bases": (Conf,)},
-)
-
-
-def _override_constructor(cls):
+def override_constructor(cls):
     @functools.wraps(cls, updated=())
     class WrappedClass(cls):
         def __new__(
             cls,
             *args,
+            name_: Optional[str] = None,
+            group_: Optional[str] = None,
+            package_: Optional[str] = "_group_",
+            provider_: Optional[str] = None,
+            defaults: Optional[list] = None,
             **kwargs,
         ):
+            zen_meta = merge_zen_meta_defaults(
+                name_, group_, package_, provider_, defaults
+            )
 
             global _configuring
             if _configuring:
-                return cls.Conf(*args, **kwargs)
+                return cls.Conf(*args, **zen_meta, **kwargs)
             else:
                 return super(WrappedClass, cls).__new__(cls)
 
         def __init__(
             self,
             *args,
+            name_: Optional[str] = None,
+            group_: Optional[str] = None,
+            package_: Optional[str] = "_group_",
+            provider_: Optional[str] = None,
+            defaults: Optional[list] = None,
             **kwargs,
         ):
+            zen_meta = merge_zen_meta_defaults(
+                name_, group_, package_, provider_, defaults
+            )
             if not hasattr(self, "conf"):
-                conf = self.Conf(*args, **kwargs)
+                conf = self.Conf(*args, **zen_meta, **kwargs)
                 setattr(self, "conf", conf)
             super().__init__(*args, **kwargs)
 
+    # functools.update_wrapper(WrappedClass,cls,updated=())
     return WrappedClass
 
 
@@ -300,8 +304,12 @@ def merge_zen_meta_defaults(name_, group_, package_, provider_, defaults):
     return zen_meta
 
 
+global cs
+cs = ConfigStore.instance()
+
+
 @dataclass
-class BatteriesIncludedConf:
+class ZenExtras:
     """Mixin that adds convenience methods to hydra_zen dataclasses."""
 
     def __post_init__(self):
@@ -342,7 +350,7 @@ class BatteriesIncludedConf:
         return load_from_yaml(file_)
 
     def to_omegaconf(self):
-        """It converts a config dataclass to an OmegaConf object.
+        """It converts a PyTorch model to an OmegaConf object.
 
         Returns:
             OmegaConf.structured(self)
@@ -368,20 +376,24 @@ class BatteriesIncludedConf:
         """
         return instantiate(self)
 
+    def unpack(self):
+        """Alias for instantiate."""
+        return self.instantiate()
+
     def store(self):
         """Stores object in the config store.
 
         Returns:
             The object itself (for chaining)
         """
-        store(
+        global cs
+        cs.store(
             name=self.name_,
             node=self,
             group=self.group_,
             package=self.package_,
             provider=self.provider_,
         )
-        # could maybe return the output of store here?
         return self
 
     def save(self, config_root, subdir=None, filename=None, resolve=False):
@@ -427,13 +439,13 @@ class BatteriesIncludedConf:
             output = self.to_yaml(*args, **kwargs)
         elif verbosity == "compact":
             d = self.to_dict()
-            _delete_keys_from_dict(d, exclude_keys)
-            _delete_null_cs_keys(d)
-            _delete_null_vals_from_dict(d)
+            delete_keys_from_dict(d, exclude_keys)
+            delete_null_cs_keys(d)
+            delete_null_vals_from_dict(d)
             output = to_yaml(OmegaConf.create(d), *args, **kwargs)
         elif verbosity == "standard":
             d = self.to_dict()
-            _delete_keys_from_dict(d, exclude_keys)
+            delete_keys_from_dict(d, exclude_keys)
             output = to_yaml(OmegaConf.create(d), *args, **kwargs)
         return print(output)
 
@@ -444,6 +456,18 @@ class BatteriesIncludedConf:
         Returns:
             A new instance of the class, with the new values set.
         """
+        # //TODO https://github.com/Cellular-Longevity/newtricks/issues/491 Fix support for hydra-zen types when using __call__ on instantiated conf
+        # current_instance_omegaconf = self.to_omegaconf()
+
+        # # current_instance_omegaconf.merge_with(newly_called_omegaconf)
+        # current_instance_omegaconf.merge_with(OmegaConf.create(dict(**kwargs)))
+
+        # # OmegaConf.to_object(current_instance_omegaconf)
+        # # it should be possible to do this ^ but it hits an error
+        # # https://github.com/mit-ll-responsible-ai/hydra-zen/issues/242
+        # # looks like it has maybe been patched in recent PR to omegaconf https://github.com/omry/omegaconf/pull/879
+
+        # return _to_object_workaround(current_instance_omegaconf)
 
         new_instance = deepcopy(self)
         for key, value in kwargs.items():
@@ -451,213 +475,6 @@ class BatteriesIncludedConf:
 
         try:
             new_instance.store()
-        except Exception:
+        except:
             pass
         return new_instance
-
-
-def _delete_keys_from_dict(dictionary, keys):
-    for key in keys:
-        with suppress(KeyError):
-            del dictionary[key]
-    for value in dictionary.values():
-        if isinstance(value, MutableMapping):
-            _delete_keys_from_dict(value, keys)
-        elif isinstance(value, list):
-            for item in value:
-                if isinstance(item, MutableMapping):
-                    _delete_keys_from_dict(item, keys)
-
-
-def _delete_null_cs_keys(dictionary):
-
-    with suppress(KeyError):
-        if dictionary["group_"] is None:
-            del dictionary["group_"]
-        if dictionary["name_"] is None:
-            del dictionary["name_"]
-        if dictionary["defaults"] == ["_self_"]:
-            del dictionary["defaults"]
-    for value in dictionary.values():
-        if isinstance(value, MutableMapping):
-            _delete_null_cs_keys(value)
-        elif isinstance(value, list):
-            for item in value:
-                if isinstance(item, MutableMapping):
-                    _delete_null_cs_keys(item)
-
-
-def _delete_null_vals_from_dict(dictionary):
-
-    for key, val in list(dictionary.items()):
-        if val is None:
-            del dictionary[key]
-        if isinstance(val, MutableMapping):
-            _delete_null_vals_from_dict(val)
-        elif isinstance(val, list):
-            for item in val:
-                if isinstance(item, MutableMapping):
-                    _delete_null_vals_from_dict(item)
-
-
-batteries_included_configures = make_custom_builds_fn(
-    populate_full_signature=True,
-    zen_dataclass={"bases": (BatteriesIncludedConf,)},
-)
-
-
-def _batteries_included_override_constructor(cls):
-    @functools.wraps(cls, updated=())
-    class WrappedClass(cls):
-        def __new__(
-            cls,
-            *args,
-            name_: Optional[str] = None,
-            group_: Optional[str] = None,
-            package_: Optional[str] = "_group_",
-            provider_: Optional[str] = None,
-            defaults: Optional[list] = None,
-            **kwargs,
-        ):
-            zen_meta = merge_zen_meta_defaults(
-                name_, group_, package_, provider_, defaults
-            )
-
-            global _configuring
-            if _configuring:
-                return cls.Conf(*args, **zen_meta, **kwargs)
-            else:
-                return super(WrappedClass, cls).__new__(cls)
-
-        def __init__(
-            self,
-            *args,
-            name_: Optional[str] = None,
-            group_: Optional[str] = None,
-            package_: Optional[str] = "_group_",
-            provider_: Optional[str] = None,
-            defaults: Optional[list] = None,
-            **kwargs,
-        ):
-            zen_meta = merge_zen_meta_defaults(
-                name_, group_, package_, provider_, defaults
-            )
-            if not hasattr(self, "conf"):
-                conf = self.Conf(*args, **zen_meta, **kwargs)
-                setattr(self, "conf", conf)
-            super().__init__(*args, **kwargs)
-
-    # functools.update_wrapper(WrappedClass,cls,updated=())
-    return WrappedClass
-
-
-def add_batteries(*args, **kwargs):
-    """
-    Dispatching for decorator. If the user passes in a single positional argument, then we assume it's a class and we call the
-    _add_conf function. Otherwise, we call the _add_custom_conf function
-
-    Returns:
-      A function that takes in a class and returns a function that takes in a class and returns a
-    function that takes in a class and returns a function that takes in a class and returns a function
-    that takes in a class and returns a function that takes in a class and returns a function that takes
-    in a class and returns a function that takes in a class and returns a function that takes in a class
-    and
-    """
-    if kwargs or len(args) != 1:
-        return _add_custom_batteries(**kwargs)
-    cls = args[0]
-    return _add_batteries(cls, **kwargs)
-
-
-def _add_custom_batteries(
-    name_: Optional[str] = None,
-    group_: Optional[str] = None,
-    package_: Optional[str] = "_group_",
-    provider_: Optional[str] = None,
-    defaults: Optional[list] = None,
-    **kwargs,
-):
-    """Returns add_conf decorator but with different default arguments to be applied to the class
-    level conf.
-
-    Args:
-        name_ (Optional[str], optional): _description_. Defaults to None.
-        group_ (Optional[str], optional): _description_. Defaults to None.
-        package_ (Optional[str], optional): _description_. Defaults to "_group_".
-        provider_ (Optional[str], optional): _description_. Defaults to None.
-        defaults (Optional[list], optional): _description_. Defaults to None.
-
-    Returns:
-        _type_: _description_
-    """
-    zen_meta = merge_zen_meta_defaults(name_, group_, package_, provider_, defaults)
-    return functools.partial(_add_batteries, zen_meta=zen_meta, **kwargs)
-
-
-def _add_batteries(
-    cls,
-    **kwargs,
-):
-    """Decorator that adds an attribute called `conf` which holds the configuration object for that
-    class.
-
-    Args:
-        cls: the class that is being decorated
-
-    Returns:
-        The class itself.
-
-    Examples:
-
-        ### decorate a class definition ###
-        @add_conf
-        class MyClass:
-            def __init__(
-                self,
-                a:str='dog',
-                b:int=3,
-                ):
-                self.a = a
-                self.b = b
-
-            def __repr__(self):
-                return f'MyClass({self.a}, {self.b})'
-
-        # config class is now available as attribute on MyClass
-        MyClassConfig = MyClass.conf
-        MyClassConfig
-        >>> types.Builds_MyClass
-
-        # create instance of config class by calling .conf
-        my_class_config_instance = MyClass.conf(a='Lily', b=117)
-        my_class_config_instance
-        >>> Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='Lily', b=117, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])
-
-        # create instance of object via hydra instantiate
-        my_class_instance = MyClass.conf(a='Lily', b=117).instantiate()
-        my_class_instance
-        >>> MyClass('Lily', 117)
-
-        # fields of .conf track the arguments used to construct the parent object
-        my_class = MyClass(a='Lily', b=117)
-        my_class.conf
-        >>> Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='Lily', b=117, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])
-
-        ### decorate an imported class ###
-        from sklearn.linear_model import LogisticRegression
-        WrappedLogisticRegression = add_conf(LogisticRegression)
-        LogisticRegressionConfig = WrappedLogisticRegression.conf
-    """
-    wrapped_cls = deepcopy(cls)
-    # validate signature of wrapped class
-    check_class_signature_does_not_include_reserved_keywords(wrapped_cls)
-    check_signature_has_defaults_for_all_parameters(wrapped_cls)
-    conf = batteries_included_configures(
-        wrapped_cls, **kwargs
-    )  # creates conf dataclass for wrapped_cls
-    setattr(wrapped_cls, "Conf", conf)  # adds conf dataclass as Conf
-    wrapped_cls = _batteries_included_override_constructor(wrapped_cls)
-    # wrapped_cls = override_mro(wrapped_cls,mro=cls.__mor__) # let's leave this as a reminder
-    wrapped_cls = make_get_state_ignore_conf(wrapped_cls)
-
-    return wrapped_cls

--- a/src/hydra_zen/structured_configs/_add_conf.py
+++ b/src/hydra_zen/structured_configs/_add_conf.py
@@ -171,7 +171,10 @@ def _add_conf(
     check_class_signature_does_not_include_reserved_keywords(wrapped_cls)
     check_signature_has_defaults_for_all_parameters(wrapped_cls)
     #conf = configures(wrapped_cls, **kwargs)  # creates conf dataclass for wrapped_cls
-    conf = builds(wrapped_cls, populate_full_signature=True, builds_bases=(ZenExtras,), zen_meta=zen_meta_defaults, **kwargs)
+    if 'zen_meta' in kwargs:
+        conf = builds(wrapped_cls, populate_full_signature=True, builds_bases=(ZenExtras,), **kwargs)
+    else:
+        conf = builds(wrapped_cls, populate_full_signature=True, builds_bases=(ZenExtras,), zen_meta=zen_meta_defaults, **kwargs)
     setattr(wrapped_cls, "Conf", conf)  # adds conf dataclass as Conf
     wrapped_cls = override_constructor(wrapped_cls)
     # wrapped_cls = override_mro(wrapped_cls,mro=cls.__mor__) # let's leave this as a reminder

--- a/src/hydra_zen/structured_configs/_add_conf.py
+++ b/src/hydra_zen/structured_configs/_add_conf.py
@@ -377,21 +377,15 @@ class BatteriesIncludedConf:
         """
         return instantiate(self)
 
-    def store(self):
-        """Stores object in the config store.
-
-        Returns:
-            The object itself (for chaining)
-        """
+    def store(self, add_to_hydra_store: bool = True):
+        """Stores object in ZenStore."""
         store(
+            self,
             name=self.name_,
-            node=self,
             group=self.group_,
-            package=self.package_,
-            provider=self.provider_,
         )
-        # could maybe return the output of store here?
-        return self
+        if add_to_hydra_store:
+            store.add_to_hydra_store()
 
     def save(self, config_root, subdir=None, filename=None, resolve=False):
         """`save` takes a `config_root` (a path to a directory), a `subdir` (a path to a

--- a/src/hydra_zen/structured_configs/_add_conf.py
+++ b/src/hydra_zen/structured_configs/_add_conf.py
@@ -28,12 +28,56 @@ from hydra_zen import (
 from hydra_zen.typing import SupportedPrimitive, ZenWrappers
 from hydra_zen.typing._implementations import DataClass_
 
+def get_zen_meta_defaults(zen_meta=None):
+    """> It returns a dictionary of default values for the `zen_meta` dictionary.
+
+    Args:
+        zen_meta (dict): a dictionary of zen_meta parameters
+
+    Returns:
+        A dictionary with the keys: name_, group_, package_, provider_, defaults.
+    """
+    _zen_meta_defaults = dict(
+        name_=None,
+        group_=None,
+        package_="_group_",
+        provider_=None,
+        defaults=["_self_"],
+    )
+    if zen_meta is None:
+        return _zen_meta_defaults
+    else:
+        _zen_meta_defaults.update(zen_meta)
+        return _zen_meta_defaults
+
+
+def merge_zen_meta_defaults(name_, group_, package_, provider_, defaults):
+    """It merges the zen_meta dictionary with the defaults dictionary.
+
+    Args:
+        name_: The name of the resource.
+        group_: The group of the resource.
+        package_: The name of the package that the resource belongs to.
+        provider_: The name of the provider.
+        defaults: The default values for the parameters.
+
+    Returns:
+        The zen_meta dictionary is being returned.
+    """
+    zen_meta = get_zen_meta_defaults()
+    zen_meta["name_"] = zen_meta.get("name") or name_
+    zen_meta["group_"] = zen_meta.get("group") or group_
+    zen_meta["package_"] = zen_meta.get("package") or package_
+    zen_meta["provider_"] = zen_meta.get("provider") or provider_
+    zen_meta["defaults"] = zen_meta.get("defaults") if defaults is None else defaults
+    return zen_meta
+
 # commenting these out for now since builds_bases is deprecated starting from hydra-zen 0.8
 # unclear if we need the functionality we were using it for
-# zen_meta_defaults = get_zen_meta_defaults()
+zen_meta_defaults = get_zen_meta_defaults()
 # configures = make_custom_builds_fn(populate_full_signature=True, builds_bases=(ZenExtras,), zen_meta=zen_meta_defaults)
 
-configures = make_custom_builds_fn(populate_full_signature=True)
+#configures = make_custom_builds_fn(populate_full_signature=True)
 
 
 def add_conf(*args, **kwargs):
@@ -126,7 +170,8 @@ def _add_conf(
     # validate signature of wrapped class
     check_class_signature_does_not_include_reserved_keywords(wrapped_cls)
     check_signature_has_defaults_for_all_parameters(wrapped_cls)
-    conf = configures(wrapped_cls, **kwargs)  # creates conf dataclass for wrapped_cls
+    #conf = configures(wrapped_cls, **kwargs)  # creates conf dataclass for wrapped_cls
+    conf = builds(wrapped_cls, populate_full_signature=True, builds_bases=(ZenExtras,), zen_meta=zen_meta_defaults, **kwargs)
     setattr(wrapped_cls, "Conf", conf)  # adds conf dataclass as Conf
     wrapped_cls = override_constructor(wrapped_cls)
     # wrapped_cls = override_mro(wrapped_cls,mro=cls.__mor__) # let's leave this as a reminder
@@ -257,51 +302,6 @@ def check_signature_has_defaults_for_all_parameters(cls_or_func):
         ]:
             if param.default is not inspect._empty:
                 defaultless_params.append(k)
-
-
-def get_zen_meta_defaults(zen_meta=None):
-    """> It returns a dictionary of default values for the `zen_meta` dictionary.
-
-    Args:
-        zen_meta (dict): a dictionary of zen_meta parameters
-
-    Returns:
-        A dictionary with the keys: name_, group_, package_, provider_, defaults.
-    """
-    _zen_meta_defaults = dict(
-        name_=None,
-        group_=None,
-        package_="_group_",
-        provider_=None,
-        defaults=["_self_"],
-    )
-    if zen_meta is None:
-        return _zen_meta_defaults
-    else:
-        _zen_meta_defaults.update(zen_meta)
-        return _zen_meta_defaults
-
-
-def merge_zen_meta_defaults(name_, group_, package_, provider_, defaults):
-    """It merges the zen_meta dictionary with the defaults dictionary.
-
-    Args:
-        name_: The name of the resource.
-        group_: The group of the resource.
-        package_: The name of the package that the resource belongs to.
-        provider_: The name of the provider.
-        defaults: The default values for the parameters.
-
-    Returns:
-        The zen_meta dictionary is being returned.
-    """
-    zen_meta = get_zen_meta_defaults()
-    zen_meta["name_"] = zen_meta.get("name") or name_
-    zen_meta["group_"] = zen_meta.get("group") or group_
-    zen_meta["package_"] = zen_meta.get("package") or package_
-    zen_meta["provider_"] = zen_meta.get("provider") or provider_
-    zen_meta["defaults"] = zen_meta.get("defaults") if defaults is None else defaults
-    return zen_meta
 
 
 global cs

--- a/src/hydra_zen/structured_configs/_add_conf.py
+++ b/src/hydra_zen/structured_configs/_add_conf.py
@@ -1,119 +1,72 @@
-import dataclasses
 import functools
 import inspect
-import warnings
 from collections.abc import MutableMapping
 from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass
-from inspect import isclass, isfunction
+
+# from inspect import isclass, isfunction
 from pathlib import Path
-from pprint import pprint
-from pydoc import locate
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Type
+from typing import Optional  # Any,; Callable,; Dict,; List,; Mapping,; Tuple,; Type
 
 from hydra.core.config_store import ConfigStore
-from omegaconf import MISSING, OmegaConf
-from typing_extensions import Literal
+from omegaconf import OmegaConf  # MISSING,
 
-from hydra_zen import (
+from hydra_zen import (  # builds,; make_config,
     builds,
     instantiate,
     load_from_yaml,
-    make_config,
-    make_custom_builds_fn,
     save_as_yaml,
+    store,
     to_yaml,
 )
-from hydra_zen.typing import SupportedPrimitive, ZenWrappers
-from hydra_zen.typing._implementations import DataClass_
 
-def get_zen_meta_defaults(zen_meta=None):
-    """> It returns a dictionary of default values for the `zen_meta` dictionary.
+# from typing_extensions import Literal
 
-    Args:
-        zen_meta (dict): a dictionary of zen_meta parameters
+# from hydra_zen.typing import SupportedPrimitive, ZenWrappers
+# from hydra_zen.typing._implementations import DataClass_
 
-    Returns:
-        A dictionary with the keys: name_, group_, package_, provider_, defaults.
-    """
-    _zen_meta_defaults = dict(
-        name_=None,
-        group_=None,
-        package_="_group_",
-        provider_=None,
-        defaults=["_self_"],
-    )
-    if zen_meta is None:
-        return _zen_meta_defaults
-    else:
-        _zen_meta_defaults.update(zen_meta)
-        return _zen_meta_defaults
-
-
-def merge_zen_meta_defaults(name_, group_, package_, provider_, defaults):
-    """It merges the zen_meta dictionary with the defaults dictionary.
-
-    Args:
-        name_: The name of the resource.
-        group_: The group of the resource.
-        package_: The name of the package that the resource belongs to.
-        provider_: The name of the provider.
-        defaults: The default values for the parameters.
-
-    Returns:
-        The zen_meta dictionary is being returned.
-    """
-    zen_meta = get_zen_meta_defaults()
-    zen_meta["name_"] = zen_meta.get("name") or name_
-    zen_meta["group_"] = zen_meta.get("group") or group_
-    zen_meta["package_"] = zen_meta.get("package") or package_
-    zen_meta["provider_"] = zen_meta.get("provider") or provider_
-    zen_meta["defaults"] = zen_meta.get("defaults") if defaults is None else defaults
-    return zen_meta
-
-# commenting these out for now since builds_bases is deprecated starting from hydra-zen 0.8
-# unclear if we need the functionality we were using it for
-zen_meta_defaults = get_zen_meta_defaults()
-# configures = make_custom_builds_fn(populate_full_signature=True, builds_bases=(ZenExtras,), zen_meta=zen_meta_defaults)
-
-#configures = make_custom_builds_fn(populate_full_signature=True)
+global cs
+cs = ConfigStore.instance()
 
 
 def add_conf(*args, **kwargs):
-    if kwargs or len(args) != 1:
+    """
+    Dispatching for decorator. If the user passes in a single positional argument, then we assume it's a class and we call the
+    _add_conf function. Otherwise, we call the _add_custom_conf function
+
+    """
+    # if kwargs or len(pos_args) > 0:
+    #     return _add_custom_conf(*pos_args, **kwargs) # returns a function that goes on to wrap the class
+    # return _add_conf(cls) # returns a wrapped class
+    if (len(kwargs) == 0) and (len(args) == 1):
+        cls = args[0]
+        return _add_conf(cls, **kwargs)
+    else:
         return _add_custom_conf(**kwargs)
-    cls = args[0]
-    return _add_conf(cls, **kwargs)
 
 
 def _add_custom_conf(
-    name_: Optional[str] = None,
-    group_: Optional[str] = None,
-    package_: Optional[str] = "_group_",
-    provider_: Optional[str] = None,
-    defaults: Optional[list] = None,
+    *pos_args,
     **kwargs,
 ):
     """Returns add_conf decorator but with different default arguments to be applied to the class
     level conf.
 
     Args:
-        name_ (Optional[str], optional): _description_. Defaults to None.
-        group_ (Optional[str], optional): _description_. Defaults to None.
-        package_ (Optional[str], optional): _description_. Defaults to "_group_".
-        provider_ (Optional[str], optional): _description_. Defaults to None.
-        defaults (Optional[list], optional): _description_. Defaults to None.
+        *pos_args: positional arguments to be passed to the class level conf
+        **kwargs: keyword arguments to be passed to the class level conf
 
     Returns:
-        _type_: _description_
+
     """
-    zen_meta = merge_zen_meta_defaults(name_, group_, package_, provider_, defaults)
-    return functools.partial(_add_conf, zen_meta=zen_meta, **kwargs)
+    return functools.partial(_add_conf, *pos_args, **kwargs)
 
 
 def _add_conf(
     cls,
+    /,
+    *pos_args,
     **kwargs,
 ):
     """Decorator that adds an attribute called `conf` which holds the configuration object for that
@@ -167,64 +120,68 @@ def _add_conf(
         LogisticRegressionConfig = WrappedLogisticRegression.conf
     """
     wrapped_cls = deepcopy(cls)
-    # validate signature of wrapped class
-    check_class_signature_does_not_include_reserved_keywords(wrapped_cls)
-    check_signature_has_defaults_for_all_parameters(wrapped_cls)
-    #conf = configures(wrapped_cls, **kwargs)  # creates conf dataclass for wrapped_cls
-    if 'zen_meta' in kwargs:
-        conf = builds(wrapped_cls, populate_full_signature=True, builds_bases=(ZenExtras,), **kwargs)
+    if "zen_meta" in kwargs:
+        _Conf = builds(
+            wrapped_cls, populate_full_signature=True, builds_bases=(Conf,), **kwargs
+        )
     else:
-        conf = builds(wrapped_cls, populate_full_signature=True, builds_bases=(ZenExtras,), zen_meta=zen_meta_defaults, **kwargs)
-    setattr(wrapped_cls, "Conf", conf)  # adds conf dataclass as Conf
-    wrapped_cls = override_constructor(wrapped_cls)
+        _Conf = builds(
+            wrapped_cls,
+            populate_full_signature=True,
+            builds_bases=(Conf,),
+            zen_meta=get_zen_meta_defaults(),
+            **kwargs,
+        )
+    setattr(wrapped_cls, "Conf", _Conf)  # adds conf dataclass as Conf
+    wrapped_cls = _override_constructor(wrapped_cls)
     # wrapped_cls = override_mro(wrapped_cls,mro=cls.__mor__) # let's leave this as a reminder
-    wrapped_cls = make_get_state_ignore_conf(wrapped_cls)
+    wrapped_cls = make_get_state_ignore_conf(wrapped_cls)  # so that pickling works
 
     return wrapped_cls
 
 
-def override_constructor(cls):
+@dataclass
+class Conf:
+    def __call__(self, **kwargs):
+        """`__call__` takes a dictionary of keyword arguments, merges them with the current
+        instance of the class, and returns a new instance of the class with the updated config.
+
+        Returns:
+            A new instance of the class, with the new values set.
+        """
+
+        new_instance = deepcopy(self)
+        for key, value in kwargs.items():
+            setattr(new_instance, key, value)
+
+        return new_instance
+
+
+def _override_constructor(cls):
     @functools.wraps(cls, updated=())
     class WrappedClass(cls):
         def __new__(
             cls,
             *args,
-            name_: Optional[str] = None,
-            group_: Optional[str] = None,
-            package_: Optional[str] = "_group_",
-            provider_: Optional[str] = None,
-            defaults: Optional[list] = None,
             **kwargs,
         ):
-            zen_meta = merge_zen_meta_defaults(
-                name_, group_, package_, provider_, defaults
-            )
 
             global _configuring
             if _configuring:
-                return cls.Conf(*args, **zen_meta, **kwargs)
+                return cls.Conf(*args, **kwargs)
             else:
                 return super(WrappedClass, cls).__new__(cls)
 
         def __init__(
             self,
             *args,
-            name_: Optional[str] = None,
-            group_: Optional[str] = None,
-            package_: Optional[str] = "_group_",
-            provider_: Optional[str] = None,
-            defaults: Optional[list] = None,
             **kwargs,
         ):
-            zen_meta = merge_zen_meta_defaults(
-                name_, group_, package_, provider_, defaults
-            )
             if not hasattr(self, "conf"):
-                conf = self.Conf(*args, **zen_meta, **kwargs)
+                conf = self.Conf(*args, **kwargs)
                 setattr(self, "conf", conf)
             super().__init__(*args, **kwargs)
 
-    # functools.update_wrapper(WrappedClass,cls,updated=())
     return WrappedClass
 
 
@@ -307,12 +264,53 @@ def check_signature_has_defaults_for_all_parameters(cls_or_func):
                 defaultless_params.append(k)
 
 
-global cs
-cs = ConfigStore.instance()
+def get_zen_meta_defaults(zen_meta=None):
+    """> It returns a dictionary of default values for the `zen_meta` dictionary.
+
+    Args:
+        zen_meta (dict): a dictionary of zen_meta parameters
+
+    Returns:
+        A dictionary with the keys: name_, group_, package_, provider_, defaults.
+    """
+    _zen_meta_defaults = dict(
+        name_=None,
+        group_=None,
+        package_="_group_",
+        provider_=None,
+        defaults=["_self_"],
+    )
+    if zen_meta is None:
+        return _zen_meta_defaults
+    else:
+        _zen_meta_defaults.update(zen_meta)
+        return _zen_meta_defaults
+
+
+def merge_zen_meta_defaults(name_, group_, package_, provider_, defaults):
+    """It merges the zen_meta dictionary with the defaults dictionary.
+
+    Args:
+        name_: The name of the resource.
+        group_: The group of the resource.
+        package_: The name of the package that the resource belongs to.
+        provider_: The name of the provider.
+        defaults: The default values for the parameters.
+
+    Returns:
+        The zen_meta dictionary is being returned.
+    """
+    zen_meta = get_zen_meta_defaults()
+    zen_meta["name_"] = zen_meta.get("name") or name_
+    zen_meta["group_"] = zen_meta.get("group") or group_
+    zen_meta["package_"] = zen_meta.get("package") or package_
+    zen_meta["provider_"] = zen_meta.get("provider") or provider_
+    zen_meta["defaults"] = zen_meta.get("defaults") if defaults is None else defaults
+    return zen_meta
 
 
 @dataclass
-class ZenExtras:
+class BatteriesIncludedConf:
     """Mixin that adds convenience methods to hydra_zen dataclasses."""
 
     def __post_init__(self):
@@ -353,7 +351,7 @@ class ZenExtras:
         return load_from_yaml(file_)
 
     def to_omegaconf(self):
-        """It converts a PyTorch model to an OmegaConf object.
+        """It converts a config dataclass to an OmegaConf object.
 
         Returns:
             OmegaConf.structured(self)
@@ -379,24 +377,20 @@ class ZenExtras:
         """
         return instantiate(self)
 
-    def unpack(self):
-        """Alias for instantiate."""
-        return self.instantiate()
-
     def store(self):
         """Stores object in the config store.
 
         Returns:
             The object itself (for chaining)
         """
-        global cs
-        cs.store(
+        store(
             name=self.name_,
             node=self,
             group=self.group_,
             package=self.package_,
             provider=self.provider_,
         )
+        # could maybe return the output of store here?
         return self
 
     def save(self, config_root, subdir=None, filename=None, resolve=False):
@@ -442,13 +436,13 @@ class ZenExtras:
             output = self.to_yaml(*args, **kwargs)
         elif verbosity == "compact":
             d = self.to_dict()
-            delete_keys_from_dict(d, exclude_keys)
-            delete_null_cs_keys(d)
-            delete_null_vals_from_dict(d)
+            _delete_keys_from_dict(d, exclude_keys)
+            _delete_null_cs_keys(d)
+            _delete_null_vals_from_dict(d)
             output = to_yaml(OmegaConf.create(d), *args, **kwargs)
         elif verbosity == "standard":
             d = self.to_dict()
-            delete_keys_from_dict(d, exclude_keys)
+            _delete_keys_from_dict(d, exclude_keys)
             output = to_yaml(OmegaConf.create(d), *args, **kwargs)
         return print(output)
 
@@ -459,18 +453,6 @@ class ZenExtras:
         Returns:
             A new instance of the class, with the new values set.
         """
-        # //TODO https://github.com/Cellular-Longevity/newtricks/issues/491 Fix support for hydra-zen types when using __call__ on instantiated conf
-        # current_instance_omegaconf = self.to_omegaconf()
-
-        # # current_instance_omegaconf.merge_with(newly_called_omegaconf)
-        # current_instance_omegaconf.merge_with(OmegaConf.create(dict(**kwargs)))
-
-        # # OmegaConf.to_object(current_instance_omegaconf)
-        # # it should be possible to do this ^ but it hits an error
-        # # https://github.com/mit-ll-responsible-ai/hydra-zen/issues/242
-        # # looks like it has maybe been patched in recent PR to omegaconf https://github.com/omry/omegaconf/pull/879
-
-        # return _to_object_workaround(current_instance_omegaconf)
 
         new_instance = deepcopy(self)
         for key, value in kwargs.items():
@@ -478,6 +460,219 @@ class ZenExtras:
 
         try:
             new_instance.store()
-        except:
+        except Exception:
             pass
         return new_instance
+
+
+def _delete_keys_from_dict(dictionary, keys):
+    for key in keys:
+        with suppress(KeyError):
+            del dictionary[key]
+    for value in dictionary.values():
+        if isinstance(value, MutableMapping):
+            _delete_keys_from_dict(value, keys)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, MutableMapping):
+                    _delete_keys_from_dict(item, keys)
+
+
+def _delete_null_cs_keys(dictionary):
+
+    with suppress(KeyError):
+        if dictionary["group_"] is None:
+            del dictionary["group_"]
+        if dictionary["name_"] is None:
+            del dictionary["name_"]
+        if dictionary["defaults"] == ["_self_"]:
+            del dictionary["defaults"]
+    for value in dictionary.values():
+        if isinstance(value, MutableMapping):
+            _delete_null_cs_keys(value)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, MutableMapping):
+                    _delete_null_cs_keys(item)
+
+
+def _delete_null_vals_from_dict(dictionary):
+
+    for key, val in list(dictionary.items()):
+        if val is None:
+            del dictionary[key]
+        if isinstance(val, MutableMapping):
+            _delete_null_vals_from_dict(val)
+        elif isinstance(val, list):
+            for item in val:
+                if isinstance(item, MutableMapping):
+                    _delete_null_vals_from_dict(item)
+
+
+def _batteries_included_override_constructor(cls):
+    @functools.wraps(cls, updated=())
+    class WrappedClass(cls):
+        def __new__(
+            cls,
+            *args,
+            name_: Optional[str] = None,
+            group_: Optional[str] = None,
+            package_: Optional[str] = "_group_",
+            provider_: Optional[str] = None,
+            defaults: Optional[list] = None,
+            **kwargs,
+        ):
+            zen_meta = merge_zen_meta_defaults(
+                name_, group_, package_, provider_, defaults
+            )
+
+            global _configuring
+            if _configuring:
+                return cls.Conf(*args, **zen_meta, **kwargs)
+            else:
+                return super(WrappedClass, cls).__new__(cls)
+
+        def __init__(
+            self,
+            *args,
+            name_: Optional[str] = None,
+            group_: Optional[str] = None,
+            package_: Optional[str] = "_group_",
+            provider_: Optional[str] = None,
+            defaults: Optional[list] = None,
+            **kwargs,
+        ):
+            zen_meta = merge_zen_meta_defaults(
+                name_, group_, package_, provider_, defaults
+            )
+            if not hasattr(self, "conf"):
+                conf = self.Conf(*args, **zen_meta, **kwargs)
+                setattr(self, "conf", conf)
+            super().__init__(*args, **kwargs)
+
+    # functools.update_wrapper(WrappedClass,cls,updated=())
+    return WrappedClass
+
+
+def add_batteries(*args, **kwargs):
+    """
+    Dispatching for decorator. If the user passes in a single positional argument, then we assume it's a class and we call the
+    _add_conf function. Otherwise, we call the _add_custom_conf function
+
+    Returns:
+      A function that takes in a class and returns a function that takes in a class and returns a
+    function that takes in a class and returns a function that takes in a class and returns a function
+    that takes in a class and returns a function that takes in a class and returns a function that takes
+    in a class and returns a function that takes in a class and returns a function that takes in a class
+    and
+    """
+    if kwargs or len(args) != 1:
+        return _add_custom_batteries(**kwargs)
+    cls = args[0]
+    return _add_batteries(cls, **kwargs)
+
+
+def _add_custom_batteries(
+    name_: Optional[str] = None,
+    group_: Optional[str] = None,
+    package_: Optional[str] = "_group_",
+    provider_: Optional[str] = None,
+    defaults: Optional[list] = None,
+    **kwargs,
+):
+    """Returns add_conf decorator but with different default arguments to be applied to the class
+    level conf.
+
+    Args:
+        name_ (Optional[str], optional): _description_. Defaults to None.
+        group_ (Optional[str], optional): _description_. Defaults to None.
+        package_ (Optional[str], optional): _description_. Defaults to "_group_".
+        provider_ (Optional[str], optional): _description_. Defaults to None.
+        defaults (Optional[list], optional): _description_. Defaults to None.
+
+    Returns:
+        _type_: _description_
+    """
+    zen_meta = merge_zen_meta_defaults(name_, group_, package_, provider_, defaults)
+    return functools.partial(_add_batteries, zen_meta=zen_meta, **kwargs)
+
+
+def _add_batteries(
+    cls,
+    **kwargs,
+):
+    """Decorator that adds an attribute called `conf` which holds the configuration object for that
+    class.
+
+    Args:
+        cls: the class that is being decorated
+
+    Returns:
+        The class itself.
+
+    Examples:
+
+        ### decorate a class definition ###
+        @add_conf
+        class MyClass:
+            def __init__(
+                self,
+                a:str='dog',
+                b:int=3,
+                ):
+                self.a = a
+                self.b = b
+
+            def __repr__(self):
+                return f'MyClass({self.a}, {self.b})'
+
+        # config class is now available as attribute on MyClass
+        MyClassConfig = MyClass.conf
+        MyClassConfig
+        >>> types.Builds_MyClass
+
+        # create instance of config class by calling .conf
+        my_class_config_instance = MyClass.conf(a='Lily', b=117)
+        my_class_config_instance
+        >>> Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='Lily', b=117, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])
+
+        # create instance of object via hydra instantiate
+        my_class_instance = MyClass.conf(a='Lily', b=117).instantiate()
+        my_class_instance
+        >>> MyClass('Lily', 117)
+
+        # fields of .conf track the arguments used to construct the parent object
+        my_class = MyClass(a='Lily', b=117)
+        my_class.conf
+        >>> Builds_MyClass(_target_='hydra_zen.funcs.zen_processing', _zen_target='__main__.MyClass', _zen_exclude=('name_', 'group_', 'package_', 'provider_', 'defaults'), a='Lily', b=117, name_=None, group_=None, package_='_group_', provider_=None, defaults=['_self_'])
+
+        ### decorate an imported class ###
+        from sklearn.linear_model import LogisticRegression
+        WrappedLogisticRegression = add_conf(LogisticRegression)
+        LogisticRegressionConfig = WrappedLogisticRegression.conf
+    """
+    wrapped_cls = deepcopy(cls)
+    # validate signature of wrapped class
+    check_class_signature_does_not_include_reserved_keywords(wrapped_cls)
+    check_signature_has_defaults_for_all_parameters(wrapped_cls)
+    if "zen_meta" in kwargs:
+        conf = builds(
+            wrapped_cls,
+            populate_full_signature=True,
+            builds_bases=(BatteriesIncludedConf,),
+            **kwargs,
+        )
+    else:
+        conf = builds(
+            wrapped_cls,
+            populate_full_signature=True,
+            builds_bases=(BatteriesIncludedConf,),
+            zen_meta=get_zen_meta_defaults(),
+            **kwargs,
+        )
+    setattr(wrapped_cls, "Conf", conf)  # adds conf dataclass as Conf
+    wrapped_cls = _batteries_included_override_constructor(wrapped_cls)
+    # wrapped_cls = override_mro(wrapped_cls,mro=cls.__mor__) # let's leave this as a reminder
+    wrapped_cls = make_get_state_ignore_conf(wrapped_cls)
+
+    return wrapped_cls

--- a/tests/test_add_conf.py
+++ b/tests/test_add_conf.py
@@ -5,7 +5,7 @@ import pytest
 from hydra_zen import (  # builds,; load_from_yaml,; make_config,; make_custom_builds_fn,; save_as_yaml,; to_yaml,
     instantiate,
 )
-from hydra_zen.structured_configs._add_conf import add_batteries, add_conf
+from hydra_zen.structured_configs._add_conf import ConfMode, add_batteries, add_conf
 
 # from functools import partial
 # from inspect import isclass
@@ -108,3 +108,20 @@ def test_add_batteries_adds_conf_with_extra_methods(wrapped_class):
     assert hasattr(wrapped_class.Conf, "instantiate")
     assert hasattr(wrapped_class.Conf, "store")
     assert hasattr(wrapped_class.Conf, "to_yaml")
+
+
+@pytest.mark.parametrize(
+    "wrapped_class",
+    [
+        simple_wrapped_class,
+        SimpleDecoratedClass,
+        SimpleBatteriesDecoratedClass,
+    ],
+)
+def test_constructing_in_ConfMode_context_creates_config(wrapped_class):
+    # broken, need to figure out updating the zen meta fields
+    with ConfMode():
+        config = wrapped_class()
+
+    assert is_dataclass(config)
+    assert isinstance(config, wrapped_class.Conf)

--- a/tests/test_add_conf.py
+++ b/tests/test_add_conf.py
@@ -5,7 +5,7 @@ import pytest
 from hydra_zen import (  # builds,; load_from_yaml,; make_config,; make_custom_builds_fn,; save_as_yaml,; to_yaml,
     instantiate,
 )
-from hydra_zen.structured_configs._add_conf import add_conf
+from hydra_zen.structured_configs._add_conf import add_batteries, add_conf
 
 # from functools import partial
 # from inspect import isclass
@@ -20,7 +20,45 @@ class SimpleClassToBeWrapped:
 
 @pytest.fixture
 def simple_wrapped_class():
-    return add_conf(SimpleClassToBeWrapped)
+    return add_conf(
+        zen_dataclass={
+            "module": "tests.test_add_conf",
+            "cls_name": "SimpleClassToBeWrapped",
+        },
+    )(SimpleClassToBeWrapped)
+
+
+@add_conf
+class SimpleDecoratedClass:
+    def __init__(self, string_field: str = "b", int_field: int = 4):
+        self.string_field = string_field
+        self.int_field = int_field
+
+
+@add_batteries
+class SimpleBatteriesDecoratedClass:
+    def __init__(self, string_field: str = "c", int_field: int = 5):
+        self.string_field = string_field
+        self.int_field = int_field
+
+
+list_of_wrapped_classes = [
+    simple_wrapped_class,
+    SimpleDecoratedClass,
+]
+
+
+@pytest.mark.parametrize(
+    "wrapped_class",
+    [
+        simple_wrapped_class,
+        SimpleDecoratedClass,
+        SimpleBatteriesDecoratedClass,
+    ],
+)
+def test_add_conf_decorator_adds_dataclass_as_Conf_attr(wrapped_class):
+    assert hasattr(wrapped_class, "Conf")
+    assert is_dataclass(wrapped_class.Conf)
 
 
 def test_add_conf_decorator_adds_dataclass_as_Conf_attr(simple_wrapped_class):
@@ -56,3 +94,17 @@ def test_class_to_config_roundtrip(simple_wrapped_class):
     assert isinstance(simple_class_instance_2, SimpleClassToBeWrapped)
     assert simple_class_instance_2.string_field == simple_class_instance.string_field
     assert simple_class_instance_2.int_field == simple_class_instance.int_field
+
+
+@pytest.mark.parametrize(
+    "wrapped_class",
+    [
+        # simple_wrapped_class,
+        # SimpleDecoratedClass,
+        SimpleBatteriesDecoratedClass,
+    ],
+)
+def test_add_batteries_adds_conf_with_extra_methods(wrapped_class):
+    assert hasattr(wrapped_class.Conf, "instantiate")
+    assert hasattr(wrapped_class.Conf, "store")
+    assert hasattr(wrapped_class.Conf, "to_yaml")

--- a/tests/test_add_conf.py
+++ b/tests/test_add_conf.py
@@ -5,13 +5,11 @@ import pytest
 from hydra_zen import (  # builds,; load_from_yaml,; make_config,; make_custom_builds_fn,; save_as_yaml,; to_yaml,
     instantiate,
 )
-from hydra_zen.structured_configs._conf import add_conf
+from hydra_zen.structured_configs._add_conf import add_conf
 
 # from functools import partial
 # from inspect import isclass
 # from typing import Any, Callable, Dict, List, Optional
-
-
 
 
 class SimpleClassToBeWrapped:
@@ -42,12 +40,19 @@ def test_instantiation_from_Conf_instance(simple_wrapped_class):
 
 
 def test_normal_construction_of_wrapped_class(simple_wrapped_class):
-    # broken
     simple_class_instance = simple_wrapped_class()
     assert isinstance(simple_class_instance, SimpleClassToBeWrapped)
 
 
 def test_class_instance_has_conf_attr(simple_wrapped_class):
-    # broken
     simple_class_instance = simple_wrapped_class()
     assert hasattr(simple_class_instance, "conf")
+
+
+def test_class_to_config_roundtrip(simple_wrapped_class):
+    simple_class_instance = simple_wrapped_class()
+    simple_config = simple_class_instance.conf
+    simple_class_instance_2 = instantiate(simple_config)
+    assert isinstance(simple_class_instance_2, SimpleClassToBeWrapped)
+    assert simple_class_instance_2.string_field == simple_class_instance.string_field
+    assert simple_class_instance_2.int_field == simple_class_instance.int_field

--- a/tests/test_add_conf.py
+++ b/tests/test_add_conf.py
@@ -5,7 +5,7 @@ import pytest
 from hydra_zen import (  # builds,; load_from_yaml,; make_config,; make_custom_builds_fn,; save_as_yaml,; to_yaml,
     instantiate,
 )
-from hydra_zen.structured_configs._add_conf import ConfMode, add_batteries, add_conf
+from hydra_zen.structured_configs._add_conf import ConfMode, add_conf #,add_batteries
 
 # from functools import partial
 # from inspect import isclass
@@ -35,11 +35,11 @@ class SimpleDecoratedClass:
         self.int_field = int_field
 
 
-@add_batteries
-class SimpleBatteriesDecoratedClass:
-    def __init__(self, string_field: str = "c", int_field: int = 5):
-        self.string_field = string_field
-        self.int_field = int_field
+# @add_batteries
+# class SimpleBatteriesDecoratedClass:
+#     def __init__(self, string_field: str = "c", int_field: int = 5):
+#         self.string_field = string_field
+#         self.int_field = int_field
 
 
 list_of_wrapped_classes = [
@@ -53,7 +53,7 @@ list_of_wrapped_classes = [
     [
         simple_wrapped_class,
         SimpleDecoratedClass,
-        SimpleBatteriesDecoratedClass,
+        # SimpleBatteriesDecoratedClass,
     ],
 )
 def test_add_conf_decorator_adds_dataclass_as_Conf_attr(wrapped_class):
@@ -101,7 +101,7 @@ def test_class_to_config_roundtrip(simple_wrapped_class):
     [
         # simple_wrapped_class,
         # SimpleDecoratedClass,
-        SimpleBatteriesDecoratedClass,
+        #SimpleBatteriesDecoratedClass,
     ],
 )
 def test_add_batteries_adds_conf_with_extra_methods(wrapped_class):
@@ -115,7 +115,7 @@ def test_add_batteries_adds_conf_with_extra_methods(wrapped_class):
     [
         simple_wrapped_class,
         SimpleDecoratedClass,
-        SimpleBatteriesDecoratedClass,
+        #SimpleBatteriesDecoratedClass,
     ],
 )
 def test_constructing_in_ConfMode_context_creates_config(wrapped_class):


### PR DESCRIPTION
## Purpose

This PR is meant to stay within the cellular-longevity fork of hydra-zen. The purpose is to get the `add_conf` and `ConfMode` functionality working with the latest version of hydra zen

## To-do
- [ ] Read [previous implementation of `like`](https://github.com/mit-ll-responsible-ai/hydra-zen/pull/219) and articulate how we differ from that if we do. See also [here](https://github.com/mit-ll-responsible-ai/hydra-zen/issues/205#issuecomment-1017951452)
- [x] Find a workaround for the deprecation of `builds_bases`. Most important item is to recapitulate the functionality of the `__call__` method in our `ZenExtras` base class
  -  Our `ZenExtras` was pretty loaded with features; may make sense to strip that down or create a simpler version
- [ ] Examine the new [zen store functionality](https://github.com/mit-ll-responsible-ai/hydra-zen/pull/331) and determine whether to replace the `.store` methods that we put into our `ZenExtras`
- [ ] Build out test suite